### PR TITLE
RAI-755 add paginated vault SDK responses

### DIFF
--- a/crates/common/src/local_db/query/fetch_vaults/mod.rs
+++ b/crates/common/src/local_db/query/fetch_vaults/mod.rs
@@ -28,6 +28,8 @@ pub struct FetchVaultsArgs {
     pub tokens: Vec<Address>,
     pub hide_zero_balance: bool,
     pub only_active_orders: bool,
+    pub page: Option<u16>,
+    pub page_size: Option<u16>,
 }
 
 const OWNERS_CLAUSE: &str = "/*OWNERS_CLAUSE*/";
@@ -65,6 +67,14 @@ const OIO_CHAIN_IDS_CLAUSE: &str = "/*OIO_CHAIN_IDS_CLAUSE*/";
 const OIO_CHAIN_IDS_BODY: &str = "AND io.chain_id IN ({list})";
 const OIO_RAINDEXES_CLAUSE: &str = "/*OIO_RAINDEXES_CLAUSE*/";
 const OIO_RAINDEXES_BODY: &str = "AND io.raindex_address IN ({list})";
+const PAGINATION_CLAUSE: &str = "/*PAGINATION_CLAUSE*/";
+const ORDER_BY_CLAUSE: &str =
+    "ORDER BY o.chain_id, o.raindex_address, o.owner, o.token, o.vault_id";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LocalDbVaultsCountRow {
+    pub vaults_count: u32,
+}
 
 pub fn build_fetch_vaults_stmt(args: &FetchVaultsArgs) -> Result<SqlStatement, SqlBuildError> {
     let mut stmt = SqlStatement::new(QUERY_TEMPLATE);
@@ -119,7 +129,42 @@ pub fn build_fetch_vaults_stmt(args: &FetchVaultsArgs) -> Result<SqlStatement, S
         stmt.replace(ONLY_ACTIVE_ORDERS_CLAUSE, "")?;
     }
 
+    if let (Some(page), Some(page_size)) = (args.page, args.page_size) {
+        let offset = (page.saturating_sub(1) as u64) * (page_size as u64);
+        let limit_placeholder = format!("?{}", stmt.params.len() + 1);
+        let offset_placeholder = format!("?{}", stmt.params.len() + 2);
+        let pagination = format!("LIMIT {} OFFSET {}", limit_placeholder, offset_placeholder);
+        stmt.replace(PAGINATION_CLAUSE, &pagination)?;
+        stmt.push(SqlValue::U64(page_size as u64));
+        stmt.push(SqlValue::U64(offset));
+    } else {
+        stmt.replace(PAGINATION_CLAUSE, "")?;
+    }
+
     Ok(stmt)
+}
+
+pub fn build_fetch_vaults_count_stmt(
+    args: &FetchVaultsArgs,
+) -> Result<SqlStatement, SqlBuildError> {
+    let count_args = FetchVaultsArgs {
+        page: None,
+        page_size: None,
+        ..args.clone()
+    };
+    let mut stmt = build_fetch_vaults_stmt(&count_args)?;
+    let inner_sql = stmt
+        .sql
+        .replace(ORDER_BY_CLAUSE, "")
+        .trim_end()
+        .trim_end_matches(';')
+        .to_string();
+    stmt.sql = format!("SELECT COUNT(*) AS vaults_count FROM ({inner_sql})");
+    Ok(stmt)
+}
+
+pub fn extract_vaults_count(rows: &[LocalDbVaultsCountRow]) -> u32 {
+    rows.first().map(|row| row.vaults_count).unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -143,6 +188,7 @@ mod tests {
         assert!(!stmt.sql.contains(ONLY_ACTIVE_ORDERS_CLAUSE));
         assert!(!stmt.sql.contains(OIO_CHAIN_IDS_CLAUSE));
         assert!(!stmt.sql.contains(OIO_RAINDEXES_CLAUSE));
+        assert!(!stmt.sql.contains(PAGINATION_CLAUSE));
         assert!(stmt.params.is_empty());
     }
 
@@ -264,5 +310,38 @@ mod tests {
         args.only_active_orders = true;
         let stmt = build_fetch_vaults_stmt(&args).unwrap();
         assert!(stmt.sql.contains("oii.owner = o.owner"));
+    }
+
+    #[test]
+    fn pagination_clause_uses_page_and_page_size() {
+        let mut args = mk_args();
+        args.page = Some(3);
+        args.page_size = Some(25);
+        let stmt = build_fetch_vaults_stmt(&args).unwrap();
+        assert!(stmt.sql.contains("LIMIT ?1 OFFSET ?2"));
+        assert_eq!(stmt.params, vec![SqlValue::U64(25), SqlValue::U64(50)]);
+    }
+
+    #[test]
+    fn count_query_omits_pagination_and_counts_wrapped_vaults() {
+        let mut args = mk_args();
+        args.page = Some(2);
+        args.page_size = Some(10);
+        let stmt = build_fetch_vaults_count_stmt(&args).unwrap();
+        assert!(stmt
+            .sql
+            .starts_with("SELECT COUNT(*) AS vaults_count FROM ("));
+        assert!(!stmt.sql.contains(ORDER_BY_CLAUSE));
+        assert!(!stmt.sql.contains("LIMIT"));
+        assert!(stmt.params.is_empty());
+    }
+
+    #[test]
+    fn extract_vaults_count_returns_zero_for_empty_rows() {
+        assert_eq!(extract_vaults_count(&[]), 0);
+        assert_eq!(
+            extract_vaults_count(&[LocalDbVaultsCountRow { vaults_count: 7 }]),
+            7
+        );
     }
 }

--- a/crates/common/src/local_db/query/fetch_vaults/query.sql
+++ b/crates/common/src/local_db/query/fetch_vaults/query.sql
@@ -158,4 +158,5 @@ WHERE 1=1
 /*TOKENS_CLAUSE*/
 /*HIDE_ZERO_BALANCE*/
 /*ONLY_ACTIVE_ORDERS_CLAUSE*/
-ORDER BY o.chain_id, o.raindex_address, o.owner, o.token, o.vault_id;
+ORDER BY o.chain_id, o.raindex_address, o.owner, o.token, o.vault_id
+/*PAGINATION_CLAUSE*/;

--- a/crates/common/src/raindex_client/local_db/query/fetch_vaults.rs
+++ b/crates/common/src/raindex_client/local_db/query/fetch_vaults.rs
@@ -1,5 +1,7 @@
-use crate::local_db::query::fetch_vaults::LocalDbVault;
-use crate::local_db::query::fetch_vaults::{build_fetch_vaults_stmt, FetchVaultsArgs};
+use crate::local_db::query::fetch_vaults::{
+    build_fetch_vaults_count_stmt, build_fetch_vaults_stmt, extract_vaults_count, FetchVaultsArgs,
+    LocalDbVault, LocalDbVaultsCountRow,
+};
 use crate::local_db::query::{LocalDbQueryError, LocalDbQueryExecutor};
 use crate::raindex_client::vaults::GetVaultsFilters;
 
@@ -12,6 +14,8 @@ impl FetchVaultsArgs {
             tokens: filters.tokens.unwrap_or_default(),
             hide_zero_balance: filters.hide_zero_balance,
             only_active_orders: filters.only_active_orders,
+            page: None,
+            page_size: None,
         }
     }
 }
@@ -28,6 +32,15 @@ pub async fn fetch_vaults<E: LocalDbQueryExecutor + ?Sized>(
 ) -> Result<Vec<LocalDbVault>, LocalDbQueryError> {
     let stmt = build_fetch_vaults_stmt(&args)?;
     exec.query_json(&stmt).await
+}
+
+pub async fn fetch_vaults_count<E: LocalDbQueryExecutor + ?Sized>(
+    exec: &E,
+    args: FetchVaultsArgs,
+) -> Result<u32, LocalDbQueryError> {
+    let stmt = build_fetch_vaults_count_stmt(&args)?;
+    let rows: Vec<LocalDbVaultsCountRow> = exec.query_json(&stmt).await?;
+    Ok(extract_vaults_count(&rows))
 }
 
 #[cfg(test)]

--- a/crates/common/src/raindex_client/local_db/vaults.rs
+++ b/crates/common/src/raindex_client/local_db/vaults.rs
@@ -2,7 +2,8 @@ use super::super::RaindexError;
 use super::{
     query::fetch_all_tokens::fetch_all_tokens,
     query::fetch_vault_balance_changes::fetch_vault_balance_changes,
-    query::fetch_vaults::fetch_vaults, LocalDb, RaindexIdentifier,
+    query::fetch_vaults::{fetch_vaults, fetch_vaults_count},
+    LocalDb, RaindexIdentifier,
 };
 use crate::raindex_client::ClientRef;
 use crate::{
@@ -58,7 +59,8 @@ impl VaultsDataSource for LocalDbVaults<'_> {
         &self,
         chain_ids: Option<Vec<u32>>,
         filters: &GetVaultsFilters,
-        _page: Option<u16>,
+        page: Option<u16>,
+        page_size: Option<u16>,
     ) -> Result<Vec<RaindexVault>, RaindexError> {
         let mut fetch_args = FetchVaultsArgs::from_filters(filters.clone());
         if let Some(ids) = chain_ids {
@@ -66,9 +68,25 @@ impl VaultsDataSource for LocalDbVaults<'_> {
                 fetch_args.chain_ids = ids;
             }
         }
+        fetch_args.page = page;
+        fetch_args.page_size = page_size;
 
         let local_vaults = fetch_vaults(self.db, fetch_args).await?;
         self.convert_local_db_vaults(local_vaults, None)
+    }
+
+    async fn count(
+        &self,
+        chain_ids: Option<Vec<u32>>,
+        filters: &GetVaultsFilters,
+    ) -> Result<u32, RaindexError> {
+        let mut fetch_args = FetchVaultsArgs::from_filters(filters.clone());
+        if let Some(ids) = chain_ids {
+            if !ids.is_empty() {
+                fetch_args.chain_ids = ids;
+            }
+        }
+        Ok(fetch_vaults_count(self.db, fetch_args).await?)
     }
 
     async fn get_by_id(
@@ -233,7 +251,7 @@ mod tests {
                 .unwrap();
             let data_source = LocalDbVaults::new(&local_db, Rc::new(client));
             let vaults = data_source
-                .list(Some(vec![42161]), &GetVaultsFilters::default(), None)
+                .list(Some(vec![42161]), &GetVaultsFilters::default(), None, None)
                 .await
                 .expect("local db vaults should load");
 
@@ -311,7 +329,7 @@ mod tests {
             let data_source = LocalDbVaults::new(&local_db, Rc::new(client));
 
             let vaults = data_source
-                .list(None, &GetVaultsFilters::default(), None)
+                .list(None, &GetVaultsFilters::default(), None, None)
                 .await
                 .expect("should query without chain_ids");
 
@@ -343,7 +361,7 @@ mod tests {
             let data_source = LocalDbVaults::new(&local_db, Rc::new(client));
 
             let vaults = data_source
-                .list(Some(vec![]), &GetVaultsFilters::default(), None)
+                .list(Some(vec![]), &GetVaultsFilters::default(), None, None)
                 .await
                 .expect("should query with empty chain_ids");
 
@@ -389,7 +407,7 @@ mod tests {
             };
 
             let vaults = data_source
-                .list(Some(vec![42161]), &filters, None)
+                .list(Some(vec![42161]), &filters, None, None)
                 .await
                 .expect("filtered vaults should load");
 

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -38,12 +38,58 @@ use raindex_subgraph_client::{
     MultiRaindexSubgraphClient, RaindexSubgraphClient, RaindexSubgraphClientError,
     SgPaginationArgs,
 };
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 use wasm_bindgen_utils::impl_wasm_traits;
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_utils::prelude::js_sys::BigInt;
 
 const DEFAULT_PAGE_SIZE: u16 = 100;
+
+fn sort_vaults_for_pagination(vaults: &mut [RaindexVault]) {
+    vaults.sort_by(|a, b| {
+        a.chain_id
+            .cmp(&b.chain_id)
+            .then_with(|| a.raindex.cmp(&b.raindex))
+            .then_with(|| a.owner.cmp(&b.owner))
+            .then_with(|| a.token.address.cmp(&b.token.address))
+            .then_with(|| a.vault_id.cmp(&b.vault_id))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+fn page_vaults(vaults: Vec<RaindexVault>, page: u16, page_size: u16) -> Vec<RaindexVault> {
+    let offset = ((page - 1) as usize) * page_size as usize;
+    vaults
+        .into_iter()
+        .skip(offset)
+        .take(page_size as usize)
+        .collect()
+}
+
+fn add_vaults_to_totals(
+    totals: &mut BTreeMap<(u32, Address), RaindexVaultTotal>,
+    vaults: Vec<RaindexVault>,
+    zero: Float,
+) -> Result<(), RaindexError> {
+    for vault in vaults {
+        if !vault.balance.gt(zero)? {
+            continue;
+        }
+        let key = (vault.chain_id, vault.token.address);
+        let total = totals.entry(key).or_insert_with(|| RaindexVaultTotal {
+            chain_id: vault.chain_id,
+            token: vault.token.clone(),
+            balance: zero,
+            balance_hex: zero.as_hex(),
+            formatted_balance: "0".to_string(),
+        });
+        total.balance = (total.balance + vault.balance)?;
+        total.balance_hex = total.balance.as_hex();
+        total.formatted_balance = total.balance.format()?;
+    }
+
+    Ok(())
+}
 
 pub(crate) struct SubgraphVaults<'a> {
     client: &'a RaindexClient,
@@ -62,7 +108,14 @@ pub(crate) trait VaultsDataSource {
         chain_ids: Option<Vec<u32>>,
         filters: &GetVaultsFilters,
         page: Option<u16>,
+        page_size: Option<u16>,
     ) -> Result<Vec<RaindexVault>, RaindexError>;
+
+    async fn count(
+        &self,
+        chain_ids: Option<Vec<u32>>,
+        filters: &GetVaultsFilters,
+    ) -> Result<u32, RaindexError>;
 
     async fn get_by_id(
         &self,
@@ -81,6 +134,141 @@ pub(crate) trait VaultsDataSource {
         &self,
         chain_ids: Option<Vec<u32>>,
     ) -> Result<Vec<RaindexVaultToken>, RaindexError>;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
+pub struct RaindexVaultsListResult {
+    vaults: RaindexVaultsList,
+    page: u16,
+    page_size: u16,
+    total_items: u32,
+    has_more: bool,
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl RaindexVaultsListResult {
+    #[wasm_bindgen(getter)]
+    pub fn items(&self) -> Vec<RaindexVault> {
+        self.vaults.items()
+    }
+
+    #[wasm_bindgen(getter, unchecked_return_type = "RaindexVaultsList")]
+    pub fn vaults(&self) -> RaindexVaultsList {
+        self.vaults.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn page(&self) -> u16 {
+        self.page
+    }
+
+    #[wasm_bindgen(getter, js_name = "pageSize")]
+    pub fn page_size(&self) -> u16 {
+        self.page_size
+    }
+
+    #[wasm_bindgen(getter, js_name = "totalItems")]
+    pub fn total_items(&self) -> u32 {
+        self.total_items
+    }
+
+    #[wasm_bindgen(getter, js_name = "hasMore")]
+    pub fn has_more(&self) -> bool {
+        self.has_more
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl RaindexVaultsListResult {
+    pub fn items(&self) -> Vec<RaindexVault> {
+        self.vaults.items()
+    }
+
+    pub fn vaults(&self) -> RaindexVaultsList {
+        self.vaults.clone()
+    }
+
+    pub fn page(&self) -> u16 {
+        self.page
+    }
+
+    pub fn page_size(&self) -> u16 {
+        self.page_size
+    }
+
+    pub fn total_items(&self) -> u32 {
+        self.total_items
+    }
+
+    pub fn has_more(&self) -> bool {
+        self.has_more
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen]
+pub struct RaindexVaultTotal {
+    chain_id: u32,
+    token: RaindexVaultToken,
+    balance: Float,
+    balance_hex: String,
+    formatted_balance: String,
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen]
+impl RaindexVaultTotal {
+    #[wasm_bindgen(getter = chainId)]
+    pub fn chain_id(&self) -> u32 {
+        self.chain_id
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn token(&self) -> RaindexVaultToken {
+        self.token.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn balance(&self) -> Float {
+        self.balance
+    }
+
+    #[wasm_bindgen(getter = balanceHex, unchecked_return_type = "Hex")]
+    pub fn balance_hex(&self) -> String {
+        self.balance_hex.clone()
+    }
+
+    #[wasm_bindgen(getter = formattedBalance)]
+    pub fn formatted_balance(&self) -> String {
+        self.formatted_balance.clone()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl RaindexVaultTotal {
+    pub fn chain_id(&self) -> u32 {
+        self.chain_id
+    }
+
+    pub fn token(&self) -> RaindexVaultToken {
+        self.token.clone()
+    }
+
+    pub fn balance(&self) -> Float {
+        self.balance
+    }
+
+    pub fn balance_hex(&self) -> String {
+        self.balance_hex.clone()
+    }
+
+    pub fn formatted_balance(&self) -> String {
+        self.formatted_balance.clone()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Tsify)]
@@ -1276,10 +1464,7 @@ impl RaindexVaultVolumeDetails {
 
 #[wasm_export]
 impl RaindexClient {
-    /// Fetches vault data from multiple subgraphs across different networks
-    ///
-    /// Queries multiple subgraphs simultaneously to retrieve vault information
-    /// across different networks.
+    /// Fetches a page of vault data from multiple networks with pagination metadata.
     ///
     /// ## Examples
     ///
@@ -1294,12 +1479,13 @@ impl RaindexClient {
     ///   console.error("Error fetching vaults:", result.error.readableMsg);
     ///   return;
     /// }
-    /// const vaults = result.value;
+    /// const { items, totalItems, hasMore } = result.value;
     /// // Do something with the vaults
     /// ```
     #[wasm_export(
         js_name = "getVaults",
-        return_description = "Array of raindex vault instances",
+        return_description = "Vault list result with pagination metadata",
+        unchecked_return_type = "RaindexVaultsListResult",
         preserve_js_class
     )]
     pub async fn get_vaults(
@@ -1316,32 +1502,160 @@ impl RaindexClient {
         #[wasm_export(param_description = "Optional page number (defaults to 1)")] page: Option<
             u16,
         >,
-    ) -> Result<RaindexVaultsList, RaindexError> {
+        #[wasm_export(
+            js_name = "pageSize",
+            param_description = "Number of vaults per page (optional, defaults to 100)"
+        )]
+        page_size: Option<u16>,
+    ) -> Result<RaindexVaultsListResult, RaindexError> {
         let filters = filters.unwrap_or_default();
-        let page_number = page.unwrap_or(1);
+        let page_number = page.unwrap_or(1).max(1);
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE).max(1);
         let ids = chain_ids.map(|ChainIds(ids)| ids);
-
         let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+        let has_subgraph_sources = !sg_ids.is_empty();
+        let has_local_source = local_db.is_some();
+        let subgraph_source_count = if has_subgraph_sources {
+            self.get_multi_subgraph_args(Some(sg_ids.clone()))?
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+        } else {
+            0
+        };
+        let use_source_pagination =
+            !(has_local_source && has_subgraph_sources) && subgraph_source_count <= 1;
 
         let mut all_vaults = Vec::new();
+        let mut total_items = 0u32;
 
         if let Some(db) = local_db {
             let local_source = LocalDbVaults::new(&db, ClientRef::new(self.clone()));
-            let vaults = local_source
-                .list(Some(local_ids), &filters, Some(page_number))
+            total_items += local_source
+                .count(Some(local_ids.clone()), &filters)
                 .await?;
-            all_vaults.extend(vaults);
+            all_vaults.extend(
+                local_source
+                    .list(
+                        Some(local_ids),
+                        &filters,
+                        use_source_pagination.then_some(page_number),
+                        use_source_pagination.then_some(page_size),
+                    )
+                    .await?,
+            );
         }
 
         if !sg_ids.is_empty() {
             let subgraph_source = SubgraphVaults::new(self);
-            let vaults = subgraph_source
-                .list(Some(sg_ids), &filters, Some(page_number))
+            total_items += subgraph_source
+                .count(Some(sg_ids.clone()), &filters)
                 .await?;
-            all_vaults.extend(vaults);
+            all_vaults.extend(
+                subgraph_source
+                    .list(
+                        Some(sg_ids),
+                        &filters,
+                        use_source_pagination.then_some(page_number),
+                        use_source_pagination.then_some(page_size),
+                    )
+                    .await?,
+            );
         }
 
-        Ok(RaindexVaultsList::new(all_vaults))
+        if !use_source_pagination {
+            sort_vaults_for_pagination(&mut all_vaults);
+            all_vaults = page_vaults(all_vaults, page_number, page_size);
+        }
+        let has_more = u32::from(page_number) * u32::from(page_size) < total_items;
+
+        Ok(RaindexVaultsListResult {
+            vaults: RaindexVaultsList::new(all_vaults),
+            page: page_number,
+            page_size,
+            total_items,
+            has_more,
+        })
+    }
+
+    /// Aggregates non-zero vault balances by chain and token.
+    #[wasm_export(
+        js_name = "getVaultTotals",
+        return_description = "Non-zero vault balance totals grouped by token",
+        unchecked_return_type = "RaindexVaultTotal[]",
+        preserve_js_class
+    )]
+    pub async fn get_vault_totals(
+        &self,
+        #[wasm_export(
+            js_name = "chainIds",
+            param_description = "Specific networks to query (optional)"
+        )]
+        chain_ids: Option<ChainIds>,
+    ) -> Result<Vec<RaindexVaultTotal>, RaindexError> {
+        let filters = GetVaultsFilters {
+            owners: vec![],
+            hide_zero_balance: true,
+            tokens: None,
+            raindex_addresses: None,
+            only_active_orders: false,
+        };
+        let page_size = 1000u16;
+        let zero = Float::zero()?;
+        let mut totals: BTreeMap<(u32, Address), RaindexVaultTotal> = BTreeMap::new();
+        let ids = chain_ids.map(|ChainIds(ids)| ids);
+        let (local_db, local_ids, sg_ids) = self.classify_chains(ids)?;
+
+        if let Some(db) = local_db {
+            let local_source = LocalDbVaults::new(&db, ClientRef::new(self.clone()));
+            let mut page = 1u16;
+
+            loop {
+                let vaults = local_source
+                    .list(
+                        Some(local_ids.clone()),
+                        &filters,
+                        Some(page),
+                        Some(page_size),
+                    )
+                    .await?;
+                let batch_len = vaults.len();
+                add_vaults_to_totals(&mut totals, vaults, zero)?;
+
+                if batch_len < page_size as usize {
+                    break;
+                }
+                page = page.checked_add(1).ok_or_else(|| {
+                    RaindexError::PreflightError(
+                        "Vault totals local pagination exhausted u16 page range".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        if !sg_ids.is_empty() {
+            let subgraph_source = SubgraphVaults::new(self);
+            let mut page = 1u16;
+
+            loop {
+                let vaults = subgraph_source
+                    .list(Some(sg_ids.clone()), &filters, Some(page), Some(page_size))
+                    .await?;
+                let batch_len = vaults.len();
+                add_vaults_to_totals(&mut totals, vaults, zero)?;
+
+                if batch_len < page_size as usize {
+                    break;
+                }
+                page = page.checked_add(1).ok_or_else(|| {
+                    RaindexError::PreflightError(
+                        "Vault totals subgraph pagination exhausted u16 page range".to_string(),
+                    )
+                })?;
+            }
+        }
+
+        Ok(totals.into_values().collect())
     }
 
     /// Fetches detailed information for a specific vault
@@ -1495,6 +1809,7 @@ impl VaultsDataSource for SubgraphVaults<'_> {
         chain_ids: Option<Vec<u32>>,
         filters: &GetVaultsFilters,
         page: Option<u16>,
+        page_size: Option<u16>,
     ) -> Result<Vec<RaindexVault>, RaindexError> {
         let raindex_client = ClientRef::new(self.client.clone());
         let multi_subgraph_args = self.client.get_multi_subgraph_args(chain_ids)?;
@@ -1502,15 +1817,40 @@ impl VaultsDataSource for SubgraphVaults<'_> {
             multi_subgraph_args.values().flatten().cloned().collect(),
         );
 
-        let vaults = client
-            .vaults_list(
-                filters.clone().try_into()?,
-                SgPaginationArgs {
-                    page: page.unwrap_or(1),
-                    page_size: DEFAULT_PAGE_SIZE,
-                },
-            )
-            .await?;
+        let sg_filters = filters.clone().try_into()?;
+        let vaults = if let Some(page) = page {
+            client
+                .vaults_list_strict(
+                    sg_filters,
+                    SgPaginationArgs {
+                        page,
+                        page_size: page_size.unwrap_or(DEFAULT_PAGE_SIZE),
+                    },
+                )
+                .await?
+        } else {
+            let mut vaults = Vec::new();
+            let mut page = 1u16;
+            let page_size = DEFAULT_PAGE_SIZE;
+
+            loop {
+                let page_vaults = client
+                    .vaults_list_strict(sg_filters.clone(), SgPaginationArgs { page, page_size })
+                    .await?;
+                let batch_len = page_vaults.len();
+                vaults.extend(page_vaults);
+                if batch_len < page_size as usize {
+                    break;
+                }
+                page = page.checked_add(1).ok_or_else(|| {
+                    RaindexError::PreflightError(
+                        "Subgraph vault pagination exhausted u16 page range".to_string(),
+                    )
+                })?;
+            }
+
+            vaults
+        };
 
         let vaults = vaults
             .iter()
@@ -1536,6 +1876,18 @@ impl VaultsDataSource for SubgraphVaults<'_> {
             .collect::<Result<Vec<RaindexVault>, RaindexError>>()?;
 
         Ok(vaults)
+    }
+
+    async fn count(
+        &self,
+        chain_ids: Option<Vec<u32>>,
+        filters: &GetVaultsFilters,
+    ) -> Result<u32, RaindexError> {
+        let multi_subgraph_args = self.client.get_multi_subgraph_args(chain_ids)?;
+        let client = MultiRaindexSubgraphClient::new(
+            multi_subgraph_args.values().flatten().cloned().collect(),
+        );
+        Ok(client.vaults_count(filters.clone().try_into()?).await?)
     }
 
     async fn get_by_id(
@@ -1951,7 +2303,7 @@ mod tests {
             );
 
             let vaults = client
-                .get_vaults(Some(ChainIds(vec![42161])), None, None)
+                .get_vaults(Some(ChainIds(vec![42161])), None, None, None)
                 .await
                 .expect("local db vaults should load");
 
@@ -2114,7 +2466,7 @@ mod tests {
             };
 
             let vaults = client
-                .get_vaults(Some(ChainIds(vec![42161])), Some(filters), None)
+                .get_vaults(Some(ChainIds(vec![42161])), Some(filters), None, None)
                 .await
                 .expect("filtered vaults should load");
 
@@ -2173,8 +2525,14 @@ mod tests {
     #[cfg(not(target_family = "wasm"))]
     mod non_wasm {
         use super::*;
-        use crate::raindex_client::tests::get_test_yaml;
-        use crate::raindex_client::tests::CHAIN_ID_1_RAINDEX_ADDRESS;
+        use crate::local_db::query::{
+            fetch_vaults::LocalDbVaultsCountRow, FromDbJson, LocalDbQueryError,
+            LocalDbQueryExecutor, SqlStatement, SqlStatementBatch,
+        };
+        use crate::raindex_client::local_db::LocalDb;
+        use crate::raindex_client::tests::{
+            get_test_yaml, new_with_local_db, CHAIN_ID_1_RAINDEX_ADDRESS,
+        };
         use alloy::hex::encode_prefixed;
         use alloy::primitives::{address, b256};
         use alloy::sol_types::SolCall;
@@ -2187,6 +2545,59 @@ mod tests {
         use serde_json::{json, Value};
         use std::sync::Arc;
         use LocalDbVault;
+
+        #[derive(Clone)]
+        struct StaticVaultDbExec {
+            vaults: Vec<LocalDbVault>,
+        }
+
+        #[async_trait::async_trait]
+        impl LocalDbQueryExecutor for StaticVaultDbExec {
+            async fn execute_batch(&self, _: &SqlStatementBatch) -> Result<(), LocalDbQueryError> {
+                Ok(())
+            }
+
+            async fn query_json<T>(&self, stmt: &SqlStatement) -> Result<T, LocalDbQueryError>
+            where
+                T: FromDbJson,
+            {
+                let value = if stmt.sql.contains("vaults_count") {
+                    serde_json::to_value(vec![LocalDbVaultsCountRow {
+                        vaults_count: self.vaults.len() as u32,
+                    }])
+                } else {
+                    serde_json::to_value(&self.vaults)
+                }
+                .map_err(|err| LocalDbQueryError::deserialization(err.to_string()))?;
+
+                serde_json::from_value(value)
+                    .map_err(|err| LocalDbQueryError::deserialization(err.to_string()))
+            }
+
+            async fn query_text(&self, _: &SqlStatement) -> Result<String, LocalDbQueryError> {
+                Ok(String::new())
+            }
+
+            async fn wipe_and_recreate(&self) -> Result<(), LocalDbQueryError> {
+                Ok(())
+            }
+        }
+
+        fn make_native_local_vault(vault_id: u64, token: &str) -> LocalDbVault {
+            LocalDbVault {
+                chain_id: 1,
+                vault_id: U256::from(vault_id),
+                token: Address::from_str(token).unwrap(),
+                owner: address!("0x0000000000000000000000000000000000000000"),
+                raindex_address: Address::from_str(CHAIN_ID_1_RAINDEX_ADDRESS).unwrap(),
+                token_name: "Local Token".to_string(),
+                token_symbol: "LTKN".to_string(),
+                token_decimals: 18,
+                balance: F1.as_hex(),
+                input_orders: None,
+                output_orders: None,
+            }
+        }
 
         #[test]
         fn test_try_from_local_trade_side_with_running_balance() {
@@ -2438,7 +2849,7 @@ mod tests {
             .unwrap();
 
             let result = raindex_client
-                .get_vaults(None, None, None)
+                .get_vaults(None, None, None, None)
                 .await
                 .unwrap()
                 .items();
@@ -2475,6 +2886,343 @@ mod tests {
                 vault2.raindex,
                 Address::from_str("0x0000000000000000000000000000000000000000").unwrap()
             );
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_returns_metadata_and_uses_page_size() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json(), get_vault2_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":1")
+                    .body_contains("\"first\":1");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = raindex_client
+                .get_vaults(Some(ChainIds(vec![1])), None, Some(2), Some(1))
+                .await
+                .unwrap();
+
+            assert_eq!(result.page(), 2);
+            assert_eq!(result.page_size(), 1);
+            assert_eq!(result.total_items(), 2);
+            assert!(!result.has_more());
+            let items = result.vaults().items();
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0].id, Bytes::from_str("0x0234").unwrap());
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_has_more() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json(), get_vault2_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":1");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = raindex_client
+                .get_vaults(Some(ChainIds(vec![1])), None, Some(1), Some(1))
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_items(), 2);
+            assert!(result.has_more());
+            assert_eq!(result.vaults().items().len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_multiple_subgraphs_slices_after_merge() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":100");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":100");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = raindex_client
+                .get_vaults(None, None, Some(1), Some(1))
+                .await
+                .unwrap();
+
+            assert_eq!(result.total_items(), 2);
+            assert!(result.has_more());
+            assert_eq!(result.vaults().items().len(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_subgraph_list_errors_if_any_source_errors() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": []
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":100");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":100");
+                then.status(500);
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let result = raindex_client
+                .get_vaults(None, None, Some(1), Some(1))
+                .await;
+
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_get_vaults_mixed_sources_slices_after_merge() {
+            let sg_server = MockServer::start_async().await;
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg2")
+                    .body_contains("\"skip\":0")
+                    .body_contains("\"first\":100");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault2_json()]
+                    }
+                }));
+            });
+
+            let local_db = LocalDb::new(StaticVaultDbExec {
+                vaults: vec![
+                    make_native_local_vault(1, "0x0000000000000000000000000000000000000001"),
+                    make_native_local_vault(2, "0x0000000000000000000000000000000000000002"),
+                ],
+            });
+            let raindex_client = new_with_local_db(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                local_db,
+                vec![1],
+            )
+            .await;
+
+            let result = raindex_client
+                .get_vaults(None, None, Some(1), Some(2))
+                .await
+                .unwrap();
+
+            assert_eq!(result.page(), 1);
+            assert_eq!(result.page_size(), 2);
+            assert_eq!(result.total_items(), 3);
+            assert!(result.has_more());
+            let items = result.vaults().items();
+            assert_eq!(items.len(), 2);
+            assert!(items.iter().all(|vault| vault.chain_id() == 1));
+        }
+
+        #[tokio::test]
+        async fn test_get_vault_totals_aggregates_and_skips_zero_balances() {
+            let sg_server = MockServer::start_async().await;
+            let mut zero_vault = get_vault2_json();
+            zero_vault["balance"] = Value::String(F0.as_hex());
+
+            let count_mock = sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"balance_not\"")
+                    .body_contains("\"first\":200");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json(), zero_vault.clone()]
+                    }
+                }));
+            });
+            sg_server.mock(|when, then| {
+                when.path("/sg1")
+                    .body_contains("\"balance_not\"")
+                    .body_contains("\"first\":1000");
+                then.status(200).json_body_obj(&json!({
+                    "data": {
+                        "vaults": [get_vault1_json(), zero_vault]
+                    }
+                }));
+            });
+
+            let raindex_client = RaindexClient::new(
+                vec![get_test_yaml(
+                    &sg_server.url("/sg1"),
+                    &sg_server.url("/sg2"),
+                    &sg_server.url("/rpc1"),
+                    &sg_server.url("/rpc2"),
+                )],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            let totals = raindex_client
+                .get_vault_totals(Some(ChainIds(vec![1])))
+                .await
+                .unwrap();
+
+            assert_eq!(totals.len(), 1);
+            assert_eq!(count_mock.hits(), 0);
+            assert_eq!(
+                totals[0].token().address(),
+                Address::from_str("0x1d80c49bbbcd1c0911346656b529df9e5c2f783d").unwrap()
+            );
+            assert!(totals[0].balance().eq(F1).unwrap());
+            assert_eq!(totals[0].balance_hex(), F1.as_hex());
+            assert_eq!(totals[0].formatted_balance(), "1");
         }
 
         #[tokio::test]
@@ -3465,7 +4213,7 @@ mod tests {
             };
 
             let result = raindex_client
-                .get_vaults(None, Some(filters), None)
+                .get_vaults(None, Some(filters), None, None)
                 .await
                 .unwrap()
                 .items();
@@ -3524,7 +4272,7 @@ mod tests {
             };
 
             let result = raindex_client
-                .get_vaults(None, Some(filters), None)
+                .get_vaults(None, Some(filters), None, None)
                 .await
                 .unwrap()
                 .items();

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -330,7 +330,10 @@ mod tests {
             )
             .await
             .unwrap();
-            let vaults = raindex_client.get_vaults(None, None, None).await.unwrap();
+            let vaults = raindex_client
+                .get_vaults(None, None, None, None)
+                .await
+                .unwrap();
             vaults.items()
         }
 

--- a/crates/subgraph/src/multi_raindex_client.rs
+++ b/crates/subgraph/src/multi_raindex_client.rs
@@ -111,10 +111,11 @@ impl MultiRaindexSubgraphClient {
         Ok(total)
     }
 
-    pub async fn vaults_list(
+    async fn vaults_list_with_policy(
         &self,
         filter_args: SgVaultsListFilterArgs,
         pagination_args: SgPaginationArgs,
+        allow_partial: bool,
     ) -> Result<Vec<SgVaultWithSubgraphName>, RaindexSubgraphClientError> {
         let futures = self.subgraphs.iter().map(|subgraph| {
             let url = subgraph.url.clone();
@@ -144,13 +145,52 @@ impl MultiRaindexSubgraphClient {
                 Err(e) => last_error = Some(e),
             }
         }
-        if all_vaults.is_empty() {
+        if (all_vaults.is_empty() || !allow_partial) && last_error.is_some() {
             if let Some(e) = last_error {
                 return Err(e);
             }
         }
 
         Ok(all_vaults)
+    }
+
+    pub async fn vaults_list(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+        pagination_args: SgPaginationArgs,
+    ) -> Result<Vec<SgVaultWithSubgraphName>, RaindexSubgraphClientError> {
+        self.vaults_list_with_policy(filter_args, pagination_args, true)
+            .await
+    }
+
+    pub async fn vaults_list_strict(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+        pagination_args: SgPaginationArgs,
+    ) -> Result<Vec<SgVaultWithSubgraphName>, RaindexSubgraphClientError> {
+        self.vaults_list_with_policy(filter_args, pagination_args, false)
+            .await
+    }
+
+    pub async fn vaults_count(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+    ) -> Result<u32, RaindexSubgraphClientError> {
+        let futures = self.subgraphs.iter().map(|subgraph| {
+            let url = subgraph.url.clone();
+            let filter_args = filter_args.clone();
+            async move {
+                let client = self.get_raindex_subgraph_client(url);
+                client.vaults_count(filter_args).await
+            }
+        });
+
+        let results = join_all(futures).await;
+        let mut total: u32 = 0;
+        for result in results {
+            total += result?;
+        }
+        Ok(total)
     }
 
     pub async fn trades_by_transaction(
@@ -1987,6 +2027,41 @@ mod tests {
         assert_eq!(vaults.len(), 1);
         assert_eq!(vaults[0].vault.id, vault_a_s1.id);
         assert_eq!(vaults[0].subgraph_name, sg1_name);
+    }
+
+    #[tokio::test]
+    async fn test_vaults_list_strict_errors_when_one_subgraph_errors() {
+        let server1 = MockServer::start_async().await;
+        let sg1_url = Url::parse(&server1.url("")).unwrap();
+
+        let server2 = MockServer::start_async().await;
+        let sg2_url = Url::parse(&server2.url("")).unwrap();
+
+        let vault_a_s1 = sample_sg_vault("s1_VA");
+        server1.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(200)
+                .json_body(json!({"data": {"vaults": [vault_a_s1]}}));
+        });
+        server2.mock(|when, then| {
+            when.method(POST).path("/");
+            then.status(500);
+        });
+
+        let client = MultiRaindexSubgraphClient::new(vec![
+            MultiSubgraphArgs {
+                url: sg1_url,
+                name: "sg_v_one_ok".to_string(),
+            },
+            MultiSubgraphArgs {
+                url: sg2_url,
+                name: "sg_v_two_error".to_string(),
+            },
+        ]);
+        let result = client
+            .vaults_list_strict(default_vault_filter_args(), default_pagination_args())
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/crates/subgraph/src/raindex_client/vault.rs
+++ b/crates/subgraph/src/raindex_client/vault.rs
@@ -13,14 +13,9 @@ impl RaindexSubgraphClient {
         Ok(vault)
     }
 
-    /// Fetch all vaults, paginated
-    pub async fn vaults_list(
-        &self,
-        filter_args: SgVaultsListFilterArgs,
-        pagination_args: SgPaginationArgs,
-    ) -> Result<Vec<SgVault>, RaindexSubgraphClientError> {
-        let pagination_variables = Self::parse_pagination_args(pagination_args);
-
+    fn vaults_list_filter(
+        filter_args: &SgVaultsListFilterArgs,
+    ) -> Option<SgVaultsListQueryFilters> {
         let balance_not = if filter_args.hide_zero_balance {
             Some(SgBytes(Float::default().get_inner().to_string()))
         } else {
@@ -50,7 +45,13 @@ impl RaindexSubgraphClient {
             None
         };
 
-        let filters = SgVaultsListQueryFilters {
+        let has_filters = !filter_args.owners.is_empty()
+            || filter_args.hide_zero_balance
+            || !filter_args.tokens.is_empty()
+            || !filter_args.raindexes.is_empty()
+            || filter_args.only_active_orders;
+
+        has_filters.then(|| SgVaultsListQueryFilters {
             owner_in: filter_args.owners.clone(),
             balance_not,
             token_in: filter_args.tokens.clone(),
@@ -58,18 +59,21 @@ impl RaindexSubgraphClient {
             orders_as_input_: None,
             orders_as_output_: None,
             or,
-        };
+        })
+    }
 
-        let has_filters = !filter_args.owners.is_empty()
-            || filter_args.hide_zero_balance
-            || !filter_args.tokens.is_empty()
-            || !filter_args.raindexes.is_empty()
-            || filter_args.only_active_orders;
+    /// Fetch all vaults, paginated
+    pub async fn vaults_list(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+        pagination_args: SgPaginationArgs,
+    ) -> Result<Vec<SgVault>, RaindexSubgraphClientError> {
+        let pagination_variables = Self::parse_pagination_args(pagination_args);
 
         let variables = SgVaultsListQueryVariables {
             first: pagination_variables.first,
             skip: pagination_variables.skip,
-            filters: if has_filters { Some(filters) } else { None },
+            filters: Self::vaults_list_filter(&filter_args),
         };
 
         let data = self
@@ -79,34 +83,71 @@ impl RaindexSubgraphClient {
         Ok(data.vaults)
     }
 
-    /// Fetch all pages of vaults_list query
-    pub async fn vaults_list_all(&self) -> Result<Vec<SgVault>, RaindexSubgraphClientError> {
+    async fn fetch_all_vaults_pages(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+    ) -> Result<Vec<SgVault>, RaindexSubgraphClientError> {
         let mut all_pages_merged = vec![];
         let mut page = 1;
 
         loop {
             let page_data = self
                 .vaults_list(
-                    SgVaultsListFilterArgs {
-                        owners: vec![],
-                        hide_zero_balance: true,
-                        tokens: vec![],
-                        raindexes: vec![],
-                        only_active_orders: false,
-                    },
+                    filter_args.clone(),
                     SgPaginationArgs {
                         page,
                         page_size: ALL_PAGES_QUERY_PAGE_SIZE,
                     },
                 )
                 .await?;
-            if page_data.is_empty() {
+            let batch_len = page_data.len();
+            all_pages_merged.extend(page_data);
+            if (batch_len as u16) < ALL_PAGES_QUERY_PAGE_SIZE {
                 break;
             }
-            all_pages_merged.extend(page_data);
-            page += 1
+            page += 1;
         }
         Ok(all_pages_merged)
+    }
+
+    /// Fetch all pages of vaults_list query
+    pub async fn vaults_list_all(&self) -> Result<Vec<SgVault>, RaindexSubgraphClientError> {
+        self.fetch_all_vaults_pages(SgVaultsListFilterArgs {
+            owners: vec![],
+            hide_zero_balance: true,
+            tokens: vec![],
+            raindexes: vec![],
+            only_active_orders: false,
+        })
+        .await
+    }
+
+    pub async fn vaults_count(
+        &self,
+        filter_args: SgVaultsListFilterArgs,
+    ) -> Result<u32, RaindexSubgraphClientError> {
+        let mut count = 0u32;
+        let mut page = 1;
+
+        loop {
+            let page_data = self
+                .vaults_list(
+                    filter_args.clone(),
+                    SgPaginationArgs {
+                        page,
+                        page_size: ALL_PAGES_QUERY_PAGE_SIZE,
+                    },
+                )
+                .await?;
+            let batch_len = page_data.len();
+            count += batch_len as u32;
+            if (batch_len as u16) < ALL_PAGES_QUERY_PAGE_SIZE {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(count)
     }
 
     /// Fetch all vault deposits + withdrawals merged paginated, for a single vault
@@ -407,6 +448,43 @@ mod tests {
         for (actual, expected) in vaults.iter().zip(expected_vaults.iter()) {
             assert_sg_vault_eq(actual, expected);
         }
+    }
+
+    #[tokio::test]
+    async fn test_vaults_count_fetches_all_pages() {
+        let sg_server = MockServer::start_async().await;
+        let client = setup_client(&sg_server);
+        let filter_args = SgVaultsListFilterArgs {
+            owners: vec![],
+            hide_zero_balance: false,
+            tokens: vec![],
+            raindexes: vec![],
+            only_active_orders: false,
+        };
+        let full_page: Vec<SgVault> = (0..ALL_PAGES_QUERY_PAGE_SIZE)
+            .map(|_| default_sg_vault())
+            .collect();
+        let final_page = vec![default_sg_vault(), default_sg_vault()];
+
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains("\"skip\":0")
+                .body_contains(format!("\"first\":{}", ALL_PAGES_QUERY_PAGE_SIZE));
+            then.status(200)
+                .json_body(json!({"data": {"vaults": full_page}}));
+        });
+        sg_server.mock(|when, then| {
+            when.method(POST)
+                .path("/")
+                .body_contains(format!("\"skip\":{}", ALL_PAGES_QUERY_PAGE_SIZE))
+                .body_contains(format!("\"first\":{}", ALL_PAGES_QUERY_PAGE_SIZE));
+            then.status(200)
+                .json_body(json!({"data": {"vaults": final_page}}));
+        });
+
+        let count = client.vaults_count(filter_args).await.unwrap();
+        assert_eq!(count, ALL_PAGES_QUERY_PAGE_SIZE as u32 + 2);
     }
 
     #[tokio::test]

--- a/packages/raindex/test/js_api/raindexClient.test.ts
+++ b/packages/raindex/test/js_api/raindexClient.test.ts
@@ -1863,7 +1863,7 @@ describe("Rain Raindex JS API Package Bindgen Tests - Raindex Client", async fun
       const raindexClient = extractWasmEncodedData(
         await RaindexClient.new([YAML]),
       );
-      const result = extractWasmEncodedData(
+      const vaultsResult = extractWasmEncodedData(
         await raindexClient.getVaults(
           undefined,
           {
@@ -1871,9 +1871,15 @@ describe("Rain Raindex JS API Package Bindgen Tests - Raindex Client", async fun
             hideZeroBalance: false,
           },
           1,
+          100,
         ),
-      ).items;
+      );
+      const result = vaultsResult.items;
 
+      assert.equal(vaultsResult.page, 1);
+      assert.equal(vaultsResult.pageSize, 100);
+      assert.equal(vaultsResult.totalItems, 2);
+      assert.equal(vaultsResult.hasMore, false);
       assert.equal(result.length, 2);
       assert.equal(result[0].vaultId, BigInt(vault1.vaultId));
       assert.equal(result[0].owner, vault1.owner);

--- a/packages/ui-components/src/__tests__/VaultsListTable.test.ts
+++ b/packages/ui-components/src/__tests__/VaultsListTable.test.ts
@@ -130,7 +130,10 @@ describe("VaultsListTable", () => {
         error: undefined,
       })),
     });
-    mockGetVaults.mockResolvedValue({ value: { items: [] }, error: undefined });
+    mockGetVaults.mockResolvedValue({
+      value: { items: [], vaults: { items: [] }, hasMore: false },
+      error: undefined,
+    });
     mockGetTokens.mockResolvedValue({ value: [], error: undefined });
   });
   it("displays vault information correctly", async () => {
@@ -418,7 +421,15 @@ describe("VaultsListTable", () => {
     mockQuery.createInfiniteQuery = vi.fn(() => ({
       subscribe: (fn: (value: any) => void) => {
         fn({
-          data: { pages: [mockVaultsListMultiple] },
+          data: {
+            pages: [
+              {
+                items: mockVaultsListMultiple.items,
+                vaults: mockVaultsListMultiple,
+                hasMore: false,
+              },
+            ],
+          },
           status: "success",
           isFetching: false,
           isFetched: true,
@@ -499,7 +510,9 @@ describe("VaultsListTable", () => {
       return {
         subscribe: (fn: (value: any) => void) => {
           fn({
-            data: { pages: [{ items: [] }] },
+            data: {
+              pages: [{ items: [], vaults: { items: [] }, hasMore: false }],
+            },
             status: "success",
             isFetching: false,
             isFetched: true,
@@ -518,6 +531,7 @@ describe("VaultsListTable", () => {
           raindexAddresses: [raindexAddress],
         }),
         expect.anything(),
+        expect.anything(),
       );
     });
   });
@@ -533,7 +547,9 @@ describe("VaultsListTable", () => {
       return {
         subscribe: (fn: (value: any) => void) => {
           fn({
-            data: { pages: [{ items: [] }] },
+            data: {
+              pages: [{ items: [], vaults: { items: [] }, hasMore: false }],
+            },
             status: "success",
             isFetching: false,
             isFetched: true,
@@ -551,6 +567,7 @@ describe("VaultsListTable", () => {
         expect.objectContaining({
           raindexAddresses: undefined,
         }),
+        expect.anything(),
         expect.anything(),
       );
     });

--- a/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
+++ b/packages/ui-components/src/lib/components/tables/VaultsListTable.svelte
@@ -23,6 +23,7 @@
 		RaindexVault,
 		RaindexVaultsList,
 		type Address,
+		type RaindexVaultsListResult,
 		type RaindexCfg
 	} from '@rainlanguage/raindex';
 	import { QKEY_TOKENS, QKEY_VAULTS } from '../../queries/keys';
@@ -120,14 +121,15 @@
 						selectedRaindexAddresses.length > 0 ? selectedRaindexAddresses : undefined,
 					onlyActiveOrders: $hideInactiveOrdersVaults
 				},
-				pageParam + 1
+				pageParam + 1,
+				DEFAULT_PAGE_SIZE
 			);
 			if (result.error) throw new Error(result.error.readableMsg);
 			return result.value;
 		},
 		initialPageParam: 0,
 		getNextPageParam(lastPage, _allPages, lastPageParam) {
-			return lastPage.items.length === DEFAULT_PAGE_SIZE ? lastPageParam + 1 : undefined;
+			return lastPage.hasMore ? lastPageParam + 1 : undefined;
 		},
 		refetchInterval: DEFAULT_REFRESH_INTERVAL,
 		enabled: true
@@ -171,7 +173,7 @@
 			// otherwise it may break wasm reference
 			const filteredVaultListResults = pages.reduce(
 				(prev, cur) => {
-					const result = cur.pickByIds(selectedIds);
+					const result = cur.vaults.pickByIds(selectedIds);
 					if (result.error) {
 						throw new Error(result.error.readableMsg);
 					}
@@ -211,7 +213,7 @@
 	const isDisabled = (item: RaindexVault, chainId: number | null) => {
 		return !isSameChainId(item, chainId) || isZeroBalance(item);
 	};
-	const AppTable = TanstackAppTable<RaindexVault, RaindexVaultsList>;
+	const AppTable = TanstackAppTable<RaindexVault, RaindexVaultsListResult>;
 </script>
 
 {#if $query}


### PR DESCRIPTION
## Motivation

REST API RAI-755 vault endpoints need SDK-owned pagination for `GET /v1/vaults` and `GET /v1/vaults/totals`. ST0x-Technology/st0x.rest.api#142 should be able to call the SDK for a page of vaults plus metadata instead of fetching all SDK pages and faking pagination locally.

## Solution

- Updated the existing `RaindexClient::get_vaults` / `getVaults(chainIds, filters, page, pageSize)` API to return page `items`, the compatibility `vaults` list, `page`, `pageSize`, `totalItems`, and `hasMore`.
- Removed the separate `get_vaults_paginated` / `getVaultsPaginated` API so consumers use the existing vault list entry point.
- Added source-level vault counts and page-size support for both subgraph and local DB paths.
- Updated mixed local DB + subgraph pagination to follow the existing trades/order-query pattern: fetch each source without source-level pagination, deterministically merge/sort, then slice the requested page once.
- Updated local DB vault count SQL to omit the final list ordering.
- Updated subgraph vault counting to walk pages and accumulate counts without retaining all vault records.
- Added `RaindexClient::get_vault_totals` / `getVaultTotals(chainIds)`, aggregating non-zero vault balances by `(chainId, token)` and exposing the lossless `Float`, `balanceHex`, and formatted balance.
- Updated the UI vault table to pass `pageSize`, use `hasMore` for infinite pagination, and account for the returned metadata wrapper.

## Compatibility

`getVaults` is still the public vault-list method, but it now returns `RaindexVaultsListResult` instead of a bare `RaindexVaultsList`. The result preserves direct `items` access and includes a `vaults` list for callers that need existing `RaindexVaultsList` helpers such as `pickByIds`.

## Checks

- `cargo fmt --all`
- `cargo test -p raindex_common local_db::query::fetch_vaults`
- `cargo test -p raindex_common raindex_client::vaults`
- `cargo test -p raindex_subgraph_client raindex_client::vault`
- `cargo check -p raindex_common -p raindex_subgraph_client`
- `nix develop .#wasm-shell -c rainix-rs-static`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/raindex`
- `nix develop .#wasm-shell -c npm run test -w @rainlanguage/raindex -- test/js_api/raindexClient.test.ts`
- `npm run test:unit -w @rainlanguage/ui-components -- --run src/__tests__/VaultsListTable.test.ts`
- `npm run check -w @rainlanguage/ui-components`

## Notes

- Intended consumer: ST0x-Technology/st0x.rest.api#142.
- Subgraph `totalItems` is exact but uses a page-walk count strategy, so very large filtered result sets can require extra subgraph requests.
- Mixed local DB + subgraph vault pages are globally sorted by stable vault identifiers before slicing, matching the SDK-owned pagination boundary.
- Totals are grouped by chain and token address to avoid cross-chain token-address ambiguity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination support for vault listings, including configurable `page` and `page_size`.
  * Vault listing responses now include pagination metadata: `page`, `pageSize`, `totalItems`, and `hasMore`.
  * Enhanced vault total calculations, aggregating balances while excluding zero-balance entries.

* **Improvements**
  * Improved pagination behavior when results come from multiple backends by providing consistent, deterministic ordering before slicing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->