### PR TITLE
Gate orderbook views during local DB bootstrap

### DIFF
--- a/packages/webapp/src/__tests__/localDbStatus.test.ts
+++ b/packages/webapp/src/__tests__/localDbStatus.test.ts
@@ -7,13 +7,15 @@ import {
 	updateNetworkStatus,
 	updateRaindexStatus,
 	updateStatus,
-	aggregateStatus
+	aggregateStatus,
+	localDbSyncGate,
+	resetLocalDbStatus,
+	seedLocalDbSyncSnapshot
 } from '../lib/stores/localDbStatus';
 
 describe('localDbStatus store', () => {
 	beforeEach(() => {
-		networkStatuses.set(new Map());
-		raindexStatuses.set(new Map());
+		resetLocalDbStatus();
 	});
 
 	describe('networkStatuses', () => {
@@ -557,6 +559,264 @@ describe('localDbStatus store', () => {
 
 			result = get(aggregateStatus);
 			expect(result.status).toBe('failure');
+		});
+	});
+
+	describe('localDbSyncGate', () => {
+		it('is idle before any configured sync status has been observed', () => {
+			expect(get(localDbSyncGate)).toEqual({ status: 'idle' });
+		});
+
+		it('does not block data views for non-destructive initial sync phases', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Fetching latest block'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
+		});
+
+		it('blocks data views while the initial dump is downloading', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Downloading initial dump'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'syncing',
+				phaseMessage: 'Downloading initial dump'
+			});
+		});
+
+		it('blocks data views while bootstrap is running', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Running bootstrap'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'syncing',
+				phaseMessage: 'Running bootstrap'
+			});
+		});
+
+		it('keeps blocking after a destructive phase until the database becomes active', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Downloading initial dump'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'syncing',
+				phaseMessage: 'Downloading initial dump'
+			});
+
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Fetching latest block'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'syncing',
+				phaseMessage: 'Downloading initial dump'
+			});
+
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'active',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'active',
+				schedulerState: 'leader'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
+		});
+
+		it('shows failure if the initial destructive sync fails after it started', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Running bootstrap'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'syncing',
+				phaseMessage: 'Running bootstrap'
+			});
+
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'failure',
+				schedulerState: 'leader',
+				error: 'bootstrap failed'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'failure',
+				error: 'bootstrap failed'
+			});
+		});
+
+		it('unblocks data views once all observed statuses become active', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'syncing',
+				schedulerState: 'leader',
+				phaseMessage: 'Running bootstrap'
+			});
+
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'active',
+				schedulerState: 'leader'
+			});
+			updateRaindexStatus({
+				raindexId: {
+					chainId: 137,
+					raindexAddress: '0x1234567890123456789012345678901234567890'
+				},
+				status: 'active',
+				schedulerState: 'leader'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
+		});
+
+		it('does not block data views during later background syncs after initial readiness', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'active',
+				schedulerState: 'leader'
+			});
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
+
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'syncing',
+				schedulerState: 'leader'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
+		});
+
+		it('shows initial sync failure before data views are ready', () => {
+			updateNetworkStatus({
+				chainId: 137,
+				status: 'failure',
+				schedulerState: 'leader',
+				error: 'dump failed'
+			});
+
+			expect(get(localDbSyncGate)).toEqual({
+				status: 'failure',
+				error: 'dump failed'
+			});
+		});
+
+		it('seeds observed statuses from the client sync snapshot', () => {
+			seedLocalDbSyncSnapshot({
+				configured: true,
+				healthy: true,
+				status: 'active',
+				schedulerState: 'leader',
+				networks: [
+					{
+						chainId: 137,
+						networkKey: 'polygon',
+						status: 'active',
+						schedulerState: 'leader',
+						raindexCount: 1,
+						ready: true
+					}
+				],
+				raindexes: [
+					{
+						raindexId: {
+							chainId: 137,
+							raindexAddress: '0x1234567890123456789012345678901234567890'
+						},
+						raindexKey: 'polygon-raindex',
+						networkKey: 'polygon',
+						status: 'active',
+						schedulerState: 'leader',
+						ready: true
+					}
+				]
+			});
+
+			expect(get(networkStatuses).get(137)?.status).toBe('active');
+			expect(get(localDbSyncGate)).toEqual({ status: 'ready' });
 		});
 	});
 });

--- a/packages/webapp/src/lib/components/LocalDbSyncGate.svelte
+++ b/packages/webapp/src/lib/components/LocalDbSyncGate.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { localDbSyncGate } from '$lib/stores/localDbStatus';
+</script>
+
+{#if $localDbSyncGate.status === 'syncing'}
+	<div
+		data-testid="local-db-syncing-notice"
+		class="mx-auto mt-12 flex max-w-2xl flex-col items-center rounded-lg border border-sky-200 bg-sky-50 px-6 py-8 text-center shadow-sm dark:border-sky-900/70 dark:bg-sky-950/30"
+	>
+		<div
+			class="mb-5 h-10 w-10 animate-spin rounded-full border-2 border-sky-200 border-t-sky-600 dark:border-sky-900 dark:border-t-sky-400"
+			aria-hidden="true"
+		></div>
+		<h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+			Local database syncing
+		</h2>
+		<p class="mt-2 max-w-lg text-sm leading-6 text-gray-600 dark:text-gray-300">
+			We are preparing the local database. Orders and vaults will appear once the initial
+			sync finishes.
+		</p>
+		{#if $localDbSyncGate.phaseMessage}
+			<p class="mt-4 text-sm font-medium text-sky-700 dark:text-sky-300">
+				{$localDbSyncGate.phaseMessage}
+			</p>
+		{/if}
+	</div>
+{:else if $localDbSyncGate.status === 'failure'}
+	<div
+		data-testid="local-db-sync-failure-notice"
+		class="mx-auto mt-12 max-w-2xl rounded-lg border border-red-200 bg-red-50 px-6 py-8 text-center shadow-sm dark:border-red-900/70 dark:bg-red-950/30"
+	>
+		<h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+			Local database sync failed
+		</h2>
+		<p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+			Orders and vaults are unavailable until the local database finishes syncing.
+		</p>
+		{#if $localDbSyncGate.error}
+			<p class="mt-4 text-sm font-medium text-red-700 dark:text-red-300">
+				{$localDbSyncGate.error}
+			</p>
+		{/if}
+	</div>
+{:else}
+	<slot />
+{/if}

--- a/packages/webapp/src/lib/stores/localDbStatus.ts
+++ b/packages/webapp/src/lib/stores/localDbStatus.ts
@@ -1,10 +1,26 @@
-import type { NetworkSyncStatus, RaindexSyncStatus } from '@rainlanguage/raindex';
+import type {
+	LocalDbSyncSnapshot,
+	NetworkSyncStatus,
+	RaindexSyncStatus
+} from '@rainlanguage/raindex';
 import { aggregateLocalDbStatus } from '@rainlanguage/ui-components';
 import { writable, derived } from 'svelte/store';
 
 export const networkStatuses = writable<Map<number, NetworkSyncStatus>>(new Map());
 
 export const raindexStatuses = writable<Map<string, RaindexSyncStatus>>(new Map());
+
+export type LocalDbSyncGateState =
+	| { status: 'idle' }
+	| { status: 'ready' }
+	| { status: 'syncing'; phaseMessage?: string }
+	| { status: 'failure'; error?: string };
+
+let initialSyncComplete = false;
+let blockingInitialSyncStarted = false;
+let lastBlockingPhaseMessage: string | undefined;
+
+const BLOCKING_SYNC_PHASE_MESSAGES = new Set(['Downloading initial dump', 'Running bootstrap']);
 
 function raindexStatusKey(status: RaindexSyncStatus): string {
 	return `${status.raindexId.chainId}:${status.raindexId.raindexAddress}`;
@@ -39,6 +55,27 @@ export function updateStatus(status: NetworkSyncStatus | RaindexSyncStatus) {
 	}
 }
 
+export function seedLocalDbSyncSnapshot(snapshot: LocalDbSyncSnapshot) {
+	if (!snapshot.configured) return;
+
+	networkStatuses.set(
+		new Map(snapshot.networks.map((status) => [status.chainId, status as NetworkSyncStatus]))
+	);
+	raindexStatuses.set(
+		new Map(
+			snapshot.raindexes.map((status) => [raindexStatusKey(status), status as RaindexSyncStatus])
+		)
+	);
+}
+
+export function resetLocalDbStatus() {
+	initialSyncComplete = false;
+	blockingInitialSyncStarted = false;
+	lastBlockingPhaseMessage = undefined;
+	networkStatuses.set(new Map());
+	raindexStatuses.set(new Map());
+}
+
 export const aggregateStatus = derived(
 	[networkStatuses, raindexStatuses],
 	([$networkMap, $raindexMap]) =>
@@ -49,3 +86,52 @@ export const aggregateStatus = derived(
 );
 
 export const localDbStatus = aggregateStatus;
+
+export const localDbSyncGate = derived(
+	[networkStatuses, raindexStatuses],
+	([$networkMap, $raindexMap]): LocalDbSyncGateState => {
+		const statuses = [...Array.from($networkMap.values()), ...Array.from($raindexMap.values())];
+
+		if (statuses.length === 0) {
+			return { status: 'idle' };
+		}
+
+		const aggregate = aggregateLocalDbStatus(statuses);
+		if (aggregate.status === 'active') {
+			initialSyncComplete = true;
+			blockingInitialSyncStarted = false;
+			lastBlockingPhaseMessage = undefined;
+			return { status: 'ready' };
+		}
+
+		if (initialSyncComplete) {
+			return { status: 'ready' };
+		}
+
+		if (aggregate.status === 'failure') {
+			blockingInitialSyncStarted = false;
+			lastBlockingPhaseMessage = undefined;
+			return { status: 'failure', error: aggregate.error };
+		}
+
+		const phaseMessage = Array.from($raindexMap.values()).find(
+			(status) =>
+				status.status === 'syncing' &&
+				status.schedulerState !== 'notLeader' &&
+				Boolean(status.phaseMessage) &&
+				BLOCKING_SYNC_PHASE_MESSAGES.has(status.phaseMessage as string)
+		)?.phaseMessage;
+
+		if (phaseMessage) {
+			blockingInitialSyncStarted = true;
+			lastBlockingPhaseMessage = phaseMessage;
+			return { status: 'syncing', phaseMessage };
+		}
+
+		if (blockingInitialSyncStarted) {
+			return { status: 'syncing', phaseMessage: lastBlockingPhaseMessage };
+		}
+
+		return { status: 'ready' };
+	}
+);

--- a/packages/webapp/src/routes/+layout.svelte
+++ b/packages/webapp/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
 	import { REGISTRY_URL } from '$lib/constants';
 	import { onMount } from 'svelte';
 	import type { RaindexClient } from '@rainlanguage/raindex';
+	import { seedLocalDbSyncSnapshot } from '$lib/stores/localDbStatus';
 
 	const { errorMessage, localDb, raindexClient, registry } = $page.data;
 	const registryManager = new RegistryManager(REGISTRY_URL);
@@ -40,12 +41,23 @@
 
 	onMount(() => {
 		if (!browser || !raindexClient || !registry) return;
-		let client = raindexClient as RaindexClient;
+		const client = raindexClient as RaindexClient;
 
 		const uniqueChainIds = client.getUniqueChainIds();
 		if (!uniqueChainIds.error) {
 			validChainIds.set(uniqueChainIds.value);
 		}
+
+		client
+			.getLocalDbSyncSnapshot()
+			.then((snapshotResult) => {
+				if (!snapshotResult.error) {
+					seedLocalDbSyncSnapshot(snapshotResult.value);
+				}
+			})
+			.catch(() => {
+				// The live status callback will continue to update the sidebar and data gate.
+			});
 	});
 
 	$: if (browser && window.navigator) {

--- a/packages/webapp/src/routes/orders/+page.svelte
+++ b/packages/webapp/src/routes/orders/+page.svelte
@@ -21,6 +21,7 @@
 	import { handleTakeOrder } from '$lib/services/handleTakeOrder';
 	import type { RaindexOrder } from '@rainlanguage/raindex';
 	import type { Hex } from 'viem';
+	import LocalDbSyncGate from '$lib/components/LocalDbSyncGate.svelte';
 
 	const { hideZeroBalanceVaults, hideInactiveOrdersVaults }: AppStoresInterface = $page.data.stores;
 
@@ -45,14 +46,16 @@
 
 <PageHeader title={'Orders'} pathname={$page.url.pathname} />
 
-<OrdersListTable
-	{selectedChainIds}
-	{showInactiveOrders}
-	{orderHash}
-	{hideZeroBalanceVaults}
-	{hideInactiveOrdersVaults}
-	{activeTokens}
-	{activeRaindexAddresses}
-	{ownerFilter}
-	handleTakeOrderModal={onTakeOrderCallback}
-/>
+<LocalDbSyncGate>
+	<OrdersListTable
+		{selectedChainIds}
+		{showInactiveOrders}
+		{orderHash}
+		{hideZeroBalanceVaults}
+		{hideInactiveOrdersVaults}
+		{activeTokens}
+		{activeRaindexAddresses}
+		{ownerFilter}
+		handleTakeOrderModal={onTakeOrderCallback}
+	/>
+</LocalDbSyncGate>

--- a/packages/webapp/src/routes/orders/[chainId]-[raindex]-[orderHash]/+page.svelte
+++ b/packages/webapp/src/routes/orders/[chainId]-[raindex]-[orderHash]/+page.svelte
@@ -28,6 +28,7 @@
 	import { handleVaultDeposit } from '$lib/services/handleVaultDeposit';
 	import { handleVaultsWithdrawAll } from '$lib/services/handleVaultsWithdrawAll';
 	import { handleTakeOrder } from '$lib/services/handleTakeOrder';
+	import LocalDbSyncGate from '$lib/components/LocalDbSyncGate.svelte';
 
 	const { orderHash, chainId, raindex } = $page.params;
 	const parsedOrderHash = orderHash as Hex;
@@ -100,15 +101,17 @@
 
 <PageHeader title="Order" pathname={$page.url.pathname} />
 
-<OrderDetail
-	chainId={parsedChainId}
-	{raindexAddress}
-	orderHash={parsedOrderHash}
-	{lightweightChartsTheme}
-	{codeMirrorTheme}
-	{onRemove}
-	{onDeposit}
-	{onWithdraw}
-	{onWithdrawAll}
-	{onTakeOrder}
-/>
+<LocalDbSyncGate>
+	<OrderDetail
+		chainId={parsedChainId}
+		{raindexAddress}
+		orderHash={parsedOrderHash}
+		{lightweightChartsTheme}
+		{codeMirrorTheme}
+		{onRemove}
+		{onDeposit}
+		{onWithdraw}
+		{onWithdrawAll}
+		{onTakeOrder}
+	/>
+</LocalDbSyncGate>

--- a/packages/webapp/src/routes/vaults/+page.svelte
+++ b/packages/webapp/src/routes/vaults/+page.svelte
@@ -20,6 +20,7 @@
 	import type { RaindexClient, RaindexVaultsList } from '@rainlanguage/raindex';
 	import { handleVaultsWithdrawAll } from '$lib/services/handleVaultsWithdrawAll';
 	import type { Hex } from 'viem';
+	import LocalDbSyncGate from '$lib/components/LocalDbSyncGate.svelte';
 
 	const { showInactiveOrders } = $page.data.stores;
 
@@ -46,14 +47,16 @@
 
 <PageHeader title="Vaults" pathname={$page.url.pathname} />
 
-<VaultsListTable
-	{orderHash}
-	{showInactiveOrders}
-	{hideZeroBalanceVaults}
-	{hideInactiveOrdersVaults}
-	{activeTokens}
-	{selectedChainIds}
-	{activeRaindexAddresses}
-	{ownerFilter}
-	{onWithdrawAll}
-/>
+<LocalDbSyncGate>
+	<VaultsListTable
+		{orderHash}
+		{showInactiveOrders}
+		{hideZeroBalanceVaults}
+		{hideInactiveOrdersVaults}
+		{activeTokens}
+		{selectedChainIds}
+		{activeRaindexAddresses}
+		{ownerFilter}
+		{onWithdrawAll}
+	/>
+</LocalDbSyncGate>

--- a/packages/webapp/src/routes/vaults/[chainId]-[raindex]-[id]/+page.svelte
+++ b/packages/webapp/src/routes/vaults/[chainId]-[raindex]-[id]/+page.svelte
@@ -12,6 +12,7 @@
 	// import { lightweightChartsTheme } from '$lib/darkMode';
 	import { handleVaultWithdraw } from '$lib/services/handleVaultWithdraw';
 	import { handleVaultDeposit } from '$lib/services/handleVaultDeposit';
+	import LocalDbSyncGate from '$lib/components/LocalDbSyncGate.svelte';
 
 	const { id, chainId, raindex } = $page.params;
 	const parsedId = id as Hex;
@@ -49,4 +50,6 @@
 
 <PageHeader title="Vault" pathname={$page.url.pathname} />
 
-<VaultDetail id={parsedId} {raindexAddress} chainId={parsedChainId} {onDeposit} {onWithdraw} />
+<LocalDbSyncGate>
+	<VaultDetail id={parsedId} {raindexAddress} chainId={parsedChainId} {onDeposit} {onWithdraw} />
+</LocalDbSyncGate>


### PR DESCRIPTION
## Summary

- Add a local DB sync gate around orders and vaults list/detail views so dump/bootstrap does not briefly render empty or not-found placeholders.
- Seed the webapp sync status from the client snapshot on layout mount, so refreshes with an already usable local DB render data immediately.
- Keep the gate narrow and sticky: it only blocks after Downloading initial dump or Running bootstrap, remains blocked through intermediate sync phases, and releases on active or failure.

## Validation

- npm run test:unit -w @rainlanguage/webapp -- --run src/__tests__/localDbStatus.test.ts
- npm run check -w @rainlanguage/webapp
- npm run lint -w @rainlanguage/webapp

## Review

- Local review pass completed. Fixed failure precedence so an initial bootstrap failure shows the failure notice instead of remaining on the syncing notice.

<img width="1686" height="911" alt="Screenshot 2026-06-18 at 14 17 04" src="https://github.com/user-attachments/assets/f2a8a2fa-826b-435e-a83b-b98d154597b3" />
<img width="1686" height="911" alt="Screenshot 2026-06-18 at 14 17 12" src="https://github.com/user-attachments/assets/b4e353cf-f704-45bd-a845-56a2bc8e97ce" />
