### PR TITLE
Fix local vault balance sender address

### DIFF
--- a/crates/common/src/local_db/query/fetch_vault_balance_changes/mod.rs
+++ b/crates/common/src/local_db/query/fetch_vault_balance_changes/mod.rs
@@ -18,6 +18,7 @@ pub struct LocalDbVaultBalanceChange {
     pub block_number: u64,
     pub block_timestamp: u64,
     pub owner: Address,
+    pub transaction_sender: Address,
     pub change_type: String,
     pub token: Address,
     pub vault_id: U256,
@@ -76,8 +77,11 @@ mod tests {
         .unwrap();
         assert!(stmt.sql.contains("params AS"));
         assert!(stmt.sql.contains("?1 AS chain_id"));
+        assert!(stmt.sql.contains("AS transactionSender"));
+        assert!(stmt.sql.contains("FROM take_orders t"));
+        assert!(stmt.sql.contains("FROM clear_v3_events c"));
         assert_eq!(stmt.params.len(), 5);
-        assert!(!stmt.sql.contains("change_type IN"));
+        assert!(!stmt.sql.contains("AND vbc.change_type IN (?"));
     }
 
     #[test]
@@ -156,6 +160,6 @@ mod tests {
         .unwrap();
         assert!(stmt.sql.contains("params AS"));
         assert_eq!(stmt.params.len(), 5);
-        assert!(!stmt.sql.contains("change_type IN"));
+        assert!(!stmt.sql.contains("AND vbc.change_type IN (?"));
     }
 }

--- a/crates/common/src/local_db/query/fetch_vault_balance_changes/query.sql
+++ b/crates/common/src/local_db/query/fetch_vault_balance_changes/query.sql
@@ -12,6 +12,56 @@ SELECT
   vbc.block_number AS blockNumber,
   vbc.block_timestamp AS blockTimestamp,
   vbc.owner,
+  COALESCE(
+    (
+      SELECT d.sender
+      FROM deposits d
+      WHERE d.chain_id = vbc.chain_id
+        AND d.raindex_address = vbc.raindex_address
+        AND d.transaction_hash = vbc.transaction_hash
+        AND d.log_index = vbc.log_index
+        AND vbc.change_type = 'DEPOSIT'
+      LIMIT 1
+    ),
+    (
+      SELECT w.sender
+      FROM withdrawals w
+      WHERE w.chain_id = vbc.chain_id
+        AND w.raindex_address = vbc.raindex_address
+        AND w.transaction_hash = vbc.transaction_hash
+        AND w.log_index = vbc.log_index
+        AND vbc.change_type = 'WITHDRAW'
+      LIMIT 1
+    ),
+    (
+      SELECT t.sender
+      FROM take_orders t
+      WHERE t.chain_id = vbc.chain_id
+        AND t.raindex_address = vbc.raindex_address
+        AND t.transaction_hash = vbc.transaction_hash
+        AND t.log_index = vbc.log_index
+        AND vbc.change_type IN ('TAKE_INPUT', 'TAKE_OUTPUT')
+      LIMIT 1
+    ),
+    (
+      SELECT c.sender
+      FROM clear_v3_events c
+      WHERE c.chain_id = vbc.chain_id
+        AND c.raindex_address = vbc.raindex_address
+        AND c.transaction_hash = vbc.transaction_hash
+        AND c.log_index = vbc.log_index
+        AND vbc.change_type IN (
+          'CLEAR_ALICE_INPUT',
+          'CLEAR_ALICE_OUTPUT',
+          'CLEAR_BOB_INPUT',
+          'CLEAR_BOB_OUTPUT',
+          'CLEAR_ALICE_BOUNTY',
+          'CLEAR_BOB_BOUNTY'
+        )
+      LIMIT 1
+    ),
+    vbc.owner
+  ) AS transactionSender,
   vbc.change_type AS changeType,
   vbc.token,
   vbc.vault_id AS vaultId,

--- a/crates/common/src/raindex_client/local_db/vaults.rs
+++ b/crates/common/src/raindex_client/local_db/vaults.rs
@@ -588,6 +588,7 @@ mod tests {
                 block_number: 12345,
                 block_timestamp: 1700000000,
                 owner,
+                transaction_sender: owner,
                 change_type: "Deposit".to_string(),
                 token,
                 vault_id,

--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -1200,7 +1200,7 @@ impl RaindexVaultBalanceChange {
 
         let transaction = RaindexTransaction::from_local_parts(
             change.transaction_hash,
-            change.owner,
+            change.transaction_sender,
             change.block_number,
             change.block_timestamp,
         )?;
@@ -2376,6 +2376,7 @@ mod tests {
 
             let amount = Float::parse("1".to_string()).unwrap();
             let running_balance = Float::parse("5".to_string()).unwrap();
+            let transaction_sender = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
             let balance_change = LocalDbVaultBalanceChange {
                 transaction_hash: b256!(
@@ -2385,6 +2386,7 @@ mod tests {
                 block_number: 1234,
                 block_timestamp: 5678,
                 owner,
+                transaction_sender,
                 change_type: "DEPOSIT".to_string(),
                 token,
                 vault_id: local_vault.vault_id.clone(),
@@ -2431,6 +2433,10 @@ mod tests {
             assert_eq!(
                 change.transaction().id(),
                 "0x00000000000000000000000000000000000000000000000000000000deadbeef"
+            );
+            assert_eq!(
+                change.transaction().from().to_lowercase(),
+                transaction_sender.to_string()
             );
         }
 


### PR DESCRIPTION
## Summary
- Resolve local vault balance change UI sender values from the decoded event sender fields instead of using the vault owner.
- Match the subgraph semantics: this is the Raindex call msg.sender recorded in the event, not necessarily the top-level Ethereum transaction from address.
- Preserve an owner fallback for unexpected local rows where no matching event row exists.

## Checks
- cargo fmt --all
- cargo test -p raindex_common fetch_vault_balance_changes --lib
- cargo test -p raindex_common try_from_local_db --lib
- cargo test -p raindex_common vault_balance_changes --lib

Closes RAI-1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault balance changes now include transaction sender information, derived from related transaction event data and falling back to the vault owner when unavailable.

* **Tests**
  * Updated unit and wasm tests to include transaction sender in fixtures and to assert it’s correctly returned.
  * Tightened SQL-generation assertions for “no filter” and empty-filter scenarios to verify the expected column aliases and filter absence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->