### PR TITLE
fix(webapp): seed selectedChainIds from validChainIds when empty

### DIFF
--- a/packages/webapp/src/lib/stores/settings.test.ts
+++ b/packages/webapp/src/lib/stores/settings.test.ts
@@ -58,6 +58,26 @@ describe('settings store', () => {
 			validChainIds.set([1, 42161]);
 			expect(get(selectedChainIds)).toEqual([1, 42161]);
 		});
+
+		it('seeds selectedChainIds with all validChainIds when selectedChainIds is empty', () => {
+			// Fresh user: no prior chain selection.
+			// When the client discovers which chains are available, select them all so
+			// orders are visible without requiring a wallet connection first.
+			validChainIds.set([1, 137, 42161]);
+
+			expect(get(selectedChainIds)).toEqual([1, 137, 42161]);
+		});
+
+		it('does not re-seed selectedChainIds when validChainIds updates and selectedChainIds is already set', () => {
+			// Returning user: their explicit selection must not be clobbered when
+			// validChainIds is refreshed (e.g. after a re-init).
+			selectedChainIds.set([1, 42161]);
+
+			validChainIds.set([1, 137, 42161]);
+
+			// 137 must NOT be auto-added; user chose 1 and 42161.
+			expect(get(selectedChainIds)).toEqual([1, 42161]);
+		});
 	});
 
 	describe('selectedChainIds localStorage persistence', () => {

--- a/packages/webapp/src/lib/stores/settings.ts
+++ b/packages/webapp/src/lib/stores/settings.ts
@@ -66,6 +66,7 @@ export const validChainIds = writable<number[]>([]);
 validChainIds.subscribe((valid) => {
 	if (valid.length > 0) {
 		selectedChainIds.update((current) => {
+			if (current.length === 0) return [...valid];
 			const filtered = current.filter((id) => valid.includes(id));
 			return filtered.length !== current.length ? filtered : current;
 		});


### PR DESCRIPTION
## What

Orders page showed nothing for fresh/wallet-disconnected users because `selectedChainIds` started as `[]` and no code ever seeded it.

`validChainIds.subscribe` only filtered stale entries — it never auto-selected chains for users with an empty selection. Connecting a wallet didn't directly fix this either (the wallet sets `chainId`, not `selectedChainIds`). In practice, users only saw orders if they had a prior chain selection persisted in localStorage, which is why the issue correlates with wallet connection: the wallet flow incidentally triggers a chain-selection UI.

## Fix

One-line guard in `validChainIds.subscribe`: when `validChainIds` first becomes non-empty and `selectedChainIds` is empty, seed `selectedChainIds` with all valid chain IDs. Returning users (non-empty `selectedChainIds` in localStorage) keep their stored selection unchanged.

```diff
 validChainIds.subscribe((valid) => {
   if (valid.length > 0) {
     selectedChainIds.update((current) => {
+      if (current.length === 0) return [...valid];
       const filtered = current.filter((id) => valid.includes(id));
       return filtered.length !== current.length ? filtered : current;
     });
   }
 });
```

## Tests

Two new unit tests in `settings.test.ts`:
- `seeds selectedChainIds with all validChainIds when selectedChainIds is empty` — fresh-user path
- `does not re-seed selectedChainIds when validChainIds updates and selectedChainIds is already set` — returning-user path (no clobber)

All seven existing pruning/persistence tests continue to pass.

Closes #2747

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain selection initialization to automatically populate available chains when no explicit selection exists, while preserving user-selected chains during subsequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->