### PR TITLE
docs(natspec): correct stale calculateClearStateChange description

### DIFF
--- a/src/concrete/raindex/RaindexV6.sol
+++ b/src/concrete/raindex/RaindexV6.sol
@@ -1103,9 +1103,11 @@ contract RaindexV6 is IRaindexV6, IMetaV1_2, ReentrancyGuard, Multicall, Raindex
     }
 
     /// Calculates the clear state change given both order calculations for order
-    /// alice and order bob. The input of each is their output multiplied by
-    /// their IO ratio and the output of each is the smaller of their maximum
-    /// output and the counterparty IO * max output.
+    /// Alice and Bob. Each order's initial output equals its own `outputMax`; its
+    /// input is that output multiplied by its IO ratio. If the resulting input
+    /// exceeds the counterparty's `outputMax`, the input is capped at the
+    /// counterparty's `outputMax` and the output is back-calculated as input
+    /// divided by IO ratio.
     /// @param aliceOrderIOCalculation Order calculation for Alice.
     /// @param bobOrderIOCalculation Order calculation for Bob.
     /// @return clearStateChange The clear state change with absolute inputs and


### PR DESCRIPTION
## Summary

Corrects the `calculateClearStateChange` function-level NatSpec inherited verbatim from the legacy OrderBook. The old prose described the output cap as "counterparty IO × max output", but the actual formula (`calculateClearStateAlice`) caps each order's **input** at the counterparty's `outputMax` and back-calculates the **output** as `input / IORatio`.

No logic or bytecode change; doc-only.

Refs #2671 (item 4 — stale `calculateClearStateChange` NatSpec).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the calculation notes for clear-state behavior, making the step-by-step math easier to understand.
  * Improved wording around how inputs and outputs are capped and back-calculated when limits are reached.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->