### PR TITLE
Tune client bootstrap sqlite cache size

### DIFF
--- a/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
+++ b/crates/common/src/raindex_client/local_db/pipeline/bootstrap.rs
@@ -6,11 +6,13 @@ use crate::local_db::{
         fetch_table_columns::{fetch_table_columns_stmt, TableColumnResponse},
         fetch_tables::{fetch_tables_stmt, TableResponse},
         fetch_target_watermark::{fetch_target_watermark_stmt, TargetWatermarkRow},
-        LocalDbQueryExecutor,
+        LocalDbQueryExecutor, SqlStatement, SqlStatementBatch,
     },
     LocalDbError, RaindexIdentifier,
 };
 use std::collections::HashSet;
+
+const BOOTSTRAP_CACHE_SIZE_SQL: &str = "PRAGMA cache_size = -25000";
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ClientBootstrapAdapter;
@@ -100,6 +102,20 @@ impl ClientBootstrapAdapter {
             .await?;
         Ok(rows.is_empty())
     }
+
+    async fn apply_dump<DB>(
+        &self,
+        db: &DB,
+        dump_stmt: &SqlStatementBatch,
+    ) -> Result<(), LocalDbError>
+    where
+        DB: LocalDbQueryExecutor + ?Sized,
+    {
+        db.query_text(&SqlStatement::new(BOOTSTRAP_CACHE_SIZE_SQL))
+            .await?;
+        db.execute_batch(dump_stmt).await?;
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait(?Send)]
@@ -114,7 +130,7 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
 
         if let Some(dump_stmt) = config.dump_stmt.as_ref() {
             if self.is_fresh_db(db, &config.raindex_id).await? {
-                db.execute_batch(dump_stmt).await?;
+                self.apply_dump(db, dump_stmt).await?;
                 return Ok(());
             }
 
@@ -126,7 +142,7 @@ impl BootstrapPipeline for ClientBootstrapAdapter {
                 Ok(_) => {}
                 Err(_) => {
                     self.clear_raindex_data(db, &config.raindex_id).await?;
-                    db.execute_batch(dump_stmt).await?;
+                    self.apply_dump(db, dump_stmt).await?;
                 }
             }
         }
@@ -731,11 +747,18 @@ mod tests {
         let db = MockDb::default()
             .with_json(&fetch_tables_stmt(), tables_json)
             .with_json(&fetch_target_watermark_stmt(&cfg.raindex_id), json!([]))
+            .with_text(&SqlStatement::new(BOOTSTRAP_CACHE_SIZE_SQL), "ok")
             .with_text(&dump_stmt, "ok");
 
         adapter.engine_run(&db, &cfg).await.unwrap();
 
-        assert_eq!(db.calls(), vec![dump_stmt.sql().to_string()]);
+        assert_eq!(
+            db.calls(),
+            vec![
+                BOOTSTRAP_CACHE_SIZE_SQL.to_string(),
+                dump_stmt.sql().to_string()
+            ]
+        );
     }
 
     #[tokio::test]
@@ -765,6 +788,7 @@ mod tests {
         for stmt in clear_batch.statements() {
             db = db.with_text(stmt, "cleared");
         }
+        db = db.with_text(&SqlStatement::new(BOOTSTRAP_CACHE_SIZE_SQL), "ok");
 
         adapter.engine_run(&db, &cfg).await.unwrap();
 
@@ -774,6 +798,7 @@ mod tests {
             .iter()
             .map(|stmt| stmt.sql().to_string())
             .collect();
+        expected.push(BOOTSTRAP_CACHE_SIZE_SQL.to_string());
         expected.push(dump_stmt.sql().to_string());
         assert_eq!(calls, expected);
     }


### PR DESCRIPTION
## Motivation

Browser local DB bootstrap spends most of its time applying the downloaded SQL dump through sqlite-web. Benchmarks with the real schema and 186,170-statement dump showed that increasing SQLite's connection-local page cache before dump execution significantly improves bootstrap time.

## What changed

- Added a client bootstrap helper that runs `PRAGMA cache_size = -25000` through the existing local DB query path immediately before applying a dump.
- Reused that helper for both dump application paths in `ClientBootstrapAdapter::engine_run`: fresh DB bootstrap and threshold-triggered rebootstrap.
- Updated unit tests to assert the pragma runs before the dump SQL.

## What intentionally did not change

- Did not use sqlite-web `transaction()`; this continues to rely only on the existing `query()` callback path.
- Did not add unsafe pragmas such as `journal_mode = OFF` or `synchronous = OFF`.
- Did not change the CLI/producer bootstrap path.
- Did not restore `cache_size` after bootstrap; this setting is intentionally left connection-local for the app session.

## Verification

- `cargo test -p raindex_common raindex_client::local_db::pipeline::bootstrap`
- `cargo test -p raindex_common`
- `cargo check --target wasm32-unknown-unknown -p raindex_common`
- `nix develop -c rainix-rs-static`
- Staged local review round with 2 read-only reviewers; both reported no actionable findings.

## Reviewer notes

The key behavior to check is ordering: `PRAGMA cache_size = -25000` should execute only when a bootstrap dump is about to be applied, and immediately before `execute_batch(dump_stmt)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database bootstrap behavior by applying a cache-related setting before loading imported data/schema dumps.
  * Made initialization more reliable across fresh database setup and rebuilds after size limits are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->