### PR TITLE
fix(webapp): make max withdrawals token-safe

### DIFF
--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -729,6 +729,28 @@ impl RaindexVault {
         Ok(RaindexVaultAllowance(allowance))
     }
 
+    /// Normalizes an amount to the largest token-decimal amount that can be withdrawn.
+    ///
+    /// Converts the provided [`Float`] through this vault token's fixed-decimal
+    /// precision, truncating any sub-token-base-unit dust, then returns it as a
+    /// [`Float`] that can be safely encoded for withdraw calldata.
+    #[wasm_export(
+        js_name = "tokenSafeWithdrawAmount",
+        return_description = "Float amount normalized to this vault token's withdrawable precision",
+        unchecked_return_type = "Float",
+        preserve_js_class
+    )]
+    pub fn token_safe_withdraw_amount(
+        &self,
+        #[wasm_export(param_description = "Amount in Float value")] amount: &Float,
+    ) -> Result<Float, RaindexError> {
+        let (fixed_amount, _) = amount.to_fixed_decimal_lossy(self.token.decimals)?;
+        Ok(Float::from_fixed_decimal(
+            fixed_amount,
+            self.token.decimals,
+        )?)
+    }
+
     /// Fetches the balance of the owner for this vault
     ///
     /// Retrieves the current balance of the vault owner.

--- a/crates/common/src/raindex_client/vaults_list.rs
+++ b/crates/common/src/raindex_client/vaults_list.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use wasm_bindgen_utils::prelude::*;
 
-use crate::raindex_client::vaults::RaindexVault;
+use crate::raindex_client::{vaults::RaindexVault, RaindexError};
 use once_cell::sync::Lazy;
 
 static ZERO_FLOAT: Lazy<Float> = Lazy::new(|| Float::parse("0".to_string()).unwrap());
@@ -18,11 +18,18 @@ impl RaindexVaultsList {
     pub fn new(vaults: Vec<RaindexVault>) -> Self {
         Self(vaults)
     }
-    pub fn get_withdrawable_vaults(&self) -> Vec<&RaindexVault> {
+    pub fn get_withdrawable_vaults(&self) -> Result<Vec<&RaindexVault>, VaultsListError> {
         self.0
             .iter()
-            .filter(|vault| vault.balance().gt(*ZERO_FLOAT).unwrap_or(false))
-            .collect()
+            .map(|vault| {
+                vault
+                    .token_safe_withdraw_amount(&vault.balance())
+                    .and_then(|amount| amount.gt(*ZERO_FLOAT).map_err(RaindexError::from))
+                    .map(|is_withdrawable| is_withdrawable.then_some(vault))
+                    .map_err(|e| VaultsListError::WithdrawAmountError(e.to_readable_msg()))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|vaults| vaults.into_iter().flatten().collect())
     }
 
     pub fn pick_by_ids(&self, ids: Vec<String>) -> RaindexVaultsList {
@@ -46,7 +53,7 @@ impl RaindexVaultsList {
 
     pub async fn get_withdraw_calldata(&self) -> Result<Bytes, VaultsListError> {
         let mut calldatas: Vec<Bytes> = Vec::new();
-        let vaults_to_withdraw = self.get_withdrawable_vaults();
+        let vaults_to_withdraw = self.get_withdrawable_vaults()?;
         // If no vaults to withdraw, return error
         if vaults_to_withdraw.is_empty() {
             return Err(VaultsListError::NoWithdrawableVaults);
@@ -60,7 +67,10 @@ impl RaindexVaultsList {
         }
         // Generate multicall calldata for all vaults
         for vault in vaults_to_withdraw {
-            match vault.build_withdraw_calldata(&vault.balance()).await {
+            let withdraw_amount = vault
+                .token_safe_withdraw_amount(&vault.balance())
+                .map_err(|e| VaultsListError::WithdrawMulticallError(e.to_readable_msg()))?;
+            match vault.build_withdraw_calldata(&withdraw_amount).await {
                 Ok(calldata) => calldatas.push(calldata),
                 Err(e) => return Err(VaultsListError::WithdrawMulticallError(e.to_readable_msg())),
             }
@@ -115,13 +125,13 @@ impl RaindexVaultsList {
     /// ```
     #[wasm_export(
         js_name = "getWithdrawableVaults",
-        return_description = "Array of vaults with non-zero balance",
+        return_description = "Array of vaults with non-zero token-withdrawable balance",
         unchecked_return_type = "RaindexVault[]",
         preserve_js_class
     )]
     pub fn get_withdrawable_vaults_wasm(&self) -> Result<Vec<RaindexVault>, VaultsListError> {
         Ok(self
-            .get_withdrawable_vaults()
+            .get_withdrawable_vaults()?
             .into_iter()
             .cloned()
             .collect())
@@ -208,6 +218,8 @@ impl RaindexVaultsList {
 pub enum VaultsListError {
     #[error("Failed to get withdraw multicall: {0}")]
     WithdrawMulticallError(String),
+    #[error("Failed to normalize withdraw amount: {0}")]
+    WithdrawAmountError(String),
     #[error("No withdrawable vaults available")]
     NoWithdrawableVaults,
     #[error("All vaults must share the same raindex for batch withdrawal")]
@@ -219,6 +231,9 @@ impl VaultsListError {
         match self {
             VaultsListError::WithdrawMulticallError(err) => {
                 format!("Failed to generate withdraw multicall: {}", err)
+            }
+            VaultsListError::WithdrawAmountError(err) => {
+                format!("Failed to normalize withdraw amount: {}", err)
             }
             VaultsListError::NoWithdrawableVaults => "No withdrawable vaults available".to_string(),
             VaultsListError::MultipleRaindexesUsed => {
@@ -251,7 +266,9 @@ mod tests {
     mod non_wasm_tests {
         use super::*;
         use crate::raindex_client::{tests::get_test_yaml, RaindexClient};
+        use alloy::{primitives::U256, sol_types::SolCall};
         use httpmock::MockServer;
+        use raindex_bindings::IRaindexV6::withdraw4Call;
         use serde_json::{json, Value};
 
         fn get_vault1_json() -> Value {
@@ -298,13 +315,13 @@ mod tests {
             })
         }
 
-        async fn get_vaults() -> Vec<RaindexVault> {
+        async fn get_vaults_for(vault1: Value, vault2: Value) -> Vec<RaindexVault> {
             let sg_server = MockServer::start_async().await;
             sg_server.mock(|when, then| {
                 when.path("/sg1");
                 then.status(200).json_body_obj(&json!({
                     "data": {
-                        "vaults": [get_vault1_json()]
+                        "vaults": [vault1]
                     }
                 }));
             });
@@ -312,7 +329,7 @@ mod tests {
                 when.path("/sg2");
                 then.status(200).json_body_obj(&json!({
                     "data": {
-                        "vaults": [get_vault2_json()]
+                        "vaults": [vault2]
                     }
                 }));
             });
@@ -337,6 +354,10 @@ mod tests {
             vaults.items()
         }
 
+        async fn get_vaults() -> Vec<RaindexVault> {
+            get_vaults_for(get_vault1_json(), get_vault2_json()).await
+        }
+
         #[tokio::test]
         async fn test_get_vaults_not_empty() {
             let vaults_list = RaindexVaultsList::new(get_vaults().await);
@@ -346,9 +367,29 @@ mod tests {
         #[tokio::test]
         async fn test_get_withdrawable_vaults() {
             let vaults_list = RaindexVaultsList::new(get_vaults().await);
-            let withdrawable_vaults = vaults_list.get_withdrawable_vaults();
+            let withdrawable_vaults = vaults_list.get_withdrawable_vaults().unwrap();
             assert_eq!(withdrawable_vaults.len(), 1);
-            assert_eq!(withdrawable_vaults[0].id().to_string(), "0x0234"); // vault2 has non-zero balance
+            assert_eq!(withdrawable_vaults[0].id().to_string(), "0x0234"); // vault2 has non-zero token-withdrawable balance
+        }
+
+        #[tokio::test]
+        async fn test_get_withdrawable_vaults_skips_token_dust() {
+            let mut dust_vault = get_vault2_json();
+            dust_vault["balance"] = Value::String(
+                Float::from_fixed_decimal(U256::from(1), 7)
+                    .unwrap()
+                    .as_hex(),
+            );
+            dust_vault["token"]["decimals"] = Value::String("6".to_string());
+
+            let vaults_list =
+                RaindexVaultsList::new(get_vaults_for(get_vault1_json(), dust_vault).await);
+
+            assert!(vaults_list.get_withdrawable_vaults().unwrap().is_empty());
+            assert!(matches!(
+                vaults_list.get_withdraw_calldata().await,
+                Err(VaultsListError::NoWithdrawableVaults)
+            ));
         }
 
         #[tokio::test]
@@ -359,6 +400,29 @@ mod tests {
             let calldata = result.unwrap();
             assert!(!calldata.is_empty());
             assert!(calldata.len() > 2); // should contain vault2's ID
+        }
+
+        #[tokio::test]
+        async fn test_get_withdraw_calldata_truncates_to_token_decimals() {
+            let mut vault = get_vault2_json();
+            vault["balance"] = Value::String(
+                Float::from_fixed_decimal(U256::from(1234567), 9)
+                    .unwrap()
+                    .as_hex(),
+            );
+            vault["token"]["decimals"] = Value::String("6".to_string());
+            let vaults_list =
+                RaindexVaultsList::new(get_vaults_for(get_vault1_json(), vault).await);
+
+            let calldata = vaults_list.get_withdraw_calldata().await.unwrap();
+            let decoded = withdraw4Call::abi_decode(&calldata).unwrap();
+
+            assert_eq!(
+                decoded.targetAmount,
+                Float::from_fixed_decimal(U256::from(1234), 6)
+                    .unwrap()
+                    .get_inner()
+            );
         }
 
         #[tokio::test]

--- a/packages/webapp/src/__tests__/WithdrawModal.test.ts
+++ b/packages/webapp/src/__tests__/WithdrawModal.test.ts
@@ -32,6 +32,16 @@ describe('WithdrawModal', () => {
 				formattedBalance: '1'
 			}
 		}),
+		tokenSafeWithdrawAmount: vi.fn(function (
+			this: RaindexVault,
+			amount: Float
+		) {
+			const decimals = Number(this.token.decimals);
+			const fixedAmount = amount.toFixedDecimalLossy(decimals);
+			if (fixedAmount.error) return fixedAmount;
+
+			return Float.fromFixedDecimal(BigInt(fixedAmount.value.value), decimals);
+		}),
 		vaultId: '1',
 		balance: Float.parse('1').value as Float,
 		formattedBalance: '1'
@@ -63,7 +73,9 @@ describe('WithdrawModal', () => {
 		render(WithdrawModal, defaultProps);
 
 		await waitFor(() => {
-			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
+			expect(
+				screen.getByText('Balance of connected wallet')
+			).toBeInTheDocument();
 		});
 
 		const amountInput = screen.getByRole('textbox');
@@ -75,6 +87,45 @@ describe('WithdrawModal', () => {
 		expect(defaultProps.onSubmit).toHaveBeenCalledTimes(1);
 		const actualArg = mockOnSubmit.mock.calls[0][0];
 		expect(actualArg.format().value).toBe('1');
+	});
+
+	it('fills MAX with a token-decimal-safe amount', async () => {
+		const mockVaultWithDust = {
+			...mockVault,
+			token: {
+				...mockVault.token,
+				decimals: '6'
+			},
+			balance: Float.fromFixedDecimal(BigInt(1123456789), 9).value as Float,
+			formattedBalance: '1.123456789'
+		} as unknown as RaindexVault;
+
+		render(WithdrawModal, {
+			...defaultProps,
+			args: {
+				...defaultProps.args,
+				vault: mockVaultWithDust
+			}
+		});
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('Balance of connected wallet')
+			).toBeInTheDocument();
+		});
+
+		await fireEvent.click(screen.getByText('MAX'));
+
+		const amountInput = screen.getByRole('textbox') as HTMLInputElement;
+		expect(amountInput.value).toBe('1.123456');
+		expect(mockVaultWithDust.tokenSafeWithdrawAmount).toHaveBeenCalledWith(
+			mockVaultWithDust.balance
+		);
+
+		await fireEvent.click(screen.getByTestId('withdraw-button'));
+
+		expect(defaultProps.onSubmit).toHaveBeenCalledTimes(1);
+		expect(mockOnSubmit.mock.calls[0][0].format().value).toBe('1.123456');
 	});
 
 	it('shows error when amount exceeds balance', async () => {
@@ -92,7 +143,9 @@ describe('WithdrawModal', () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
+			expect(
+				screen.getByText('Balance of connected wallet')
+			).toBeInTheDocument();
 		});
 
 		const amountInput = screen.getByRole('textbox');
@@ -107,7 +160,9 @@ describe('WithdrawModal', () => {
 		render(WithdrawModal, defaultProps);
 
 		await waitFor(() => {
-			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
+			expect(
+				screen.getByText('Balance of connected wallet')
+			).toBeInTheDocument();
 		});
 
 		const amountInput = screen.getByRole('textbox');
@@ -132,7 +187,9 @@ describe('WithdrawModal', () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText('Balance of connected wallet')).toBeInTheDocument();
+			expect(
+				screen.getByText('Balance of connected wallet')
+			).toBeInTheDocument();
 		});
 
 		const amountInput = screen.getByRole('textbox');
@@ -198,7 +255,9 @@ describe('WithdrawModal', () => {
 
 		await waitFor(() => {
 			expect(
-				screen.getByText(truncateEthAddress('0x0000000000000000000000000000000000000000'))
+				screen.getByText(
+					truncateEthAddress('0x0000000000000000000000000000000000000000')
+				)
 			).toBeInTheDocument();
 		});
 	});
@@ -224,7 +283,9 @@ describe('WithdrawModal', () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText('Connect your wallet to continue.')).toBeInTheDocument();
+			expect(
+				screen.getByText('Connect your wallet to continue.')
+			).toBeInTheDocument();
 			expect(screen.queryByTestId('withdraw-button')).not.toBeInTheDocument();
 		});
 	});

--- a/packages/webapp/src/lib/components/WithdrawModal.svelte
+++ b/packages/webapp/src/lib/components/WithdrawModal.svelte
@@ -29,6 +29,13 @@
 	let errorMessage = '';
 	let isCheckingCalldata = false;
 
+	function getTokenSafeMaxWithdrawAmount(): Float {
+		const amount = vault.tokenSafeWithdrawAmount(vault.balance);
+		if (amount.error) return Float.parse('0').value as Float;
+
+		return amount.value;
+	}
+
 	const getUserBalance = async () => {
 		const balance = await vault.getOwnerBalance();
 		if (balance.error) {
@@ -85,7 +92,11 @@
 				<p>Connect your wallet to continue.</p>
 			{/if}
 		</div>
-		<InputTokenAmount bind:value={amount} symbol={vault.token.symbol} maxValue={vault.balance} />
+		<InputTokenAmount
+			bind:value={amount}
+			symbol={vault.token.symbol}
+			maxValue={getTokenSafeMaxWithdrawAmount()}
+		/>
 		<div class="flex flex-col justify-end gap-2">
 			<div class="flex gap-2">
 				<Button color="alternative" on:click={handleClose}>Cancel</Button>


### PR DESCRIPTION
## Summary

Fixes the MAX-withdraw path for vault balances whose internal Float precision is finer than the token's ERC20 decimals.

Previously MAX used the raw vault Float balance. When that balance included sub-token-base-unit dust, converting it into withdraw calldata could hit a lossy decimal Float conversion error. The MAX amount now truncates to the token's decimals before it is shown/submitted, and withdraw-all calldata generation uses the same token-safe amount.

## Changes

- Add `RaindexVault::token_safe_withdraw_amount`, which converts a Float through the token's fixed-decimal precision and back into a clean withdrawable Float.
- Use that token-safe amount when filtering withdrawable vaults and building withdraw-all calldata, skipping dust-only vaults.
- Use the same token-safe amount for the webapp withdraw modal MAX value.
- Add Rust coverage for dust-only vaults and truncating withdraw-all calldata.
- Add webapp coverage that MAX fills a token-decimal-safe amount.

## Tests

- `cargo fmt --all`
- `cargo test -p raindex_common`
- `cargo test -p raindex_common raindex_client::vaults_list::tests::non_wasm_tests`
- `cargo check -p raindex_common`
- `nix develop .#wasm-shell -c rainix-rs-static`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/raindex`
- `npm run test:unit -w @rainlanguage/webapp -- --run WithdrawModal.test.ts`
- `npm run svelte-lint-format-check -w @rainlanguage/webapp`

Also attempted `npm run test -w @rainlanguage/webapp`; the full suite failed in `fullDeployment.test.ts` while creating the remote registry (`HTTP request failed: builder error`) before that suite's tests ran.

Fixes RAI-1186.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Withdraw amounts are now automatically limited to the token’s supported decimal precision, reducing accidental over-withdrawals from tiny “dust” balances.
  * The Withdraw modal’s **MAX** action now fills in a token-safe amount.

* **Bug Fixes**
  * Withdrawable vaults are filtered more accurately, so balances that can’t be safely withdrawn no longer appear as available.
  * Withdraw transaction details now use the truncated, token-safe amount when building withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->