### PR TITLE
fix: rename the codegen script to script/Build.sol

### DIFF
--- a/.github/workflows/copy-artifacts.yaml
+++ b/.github/workflows/copy-artifacts.yaml
@@ -4,6 +4,6 @@ jobs:
   copy-artifacts:
     # Build from committed sources and assert the committed meta/pointer
     # artifacts are still current. The meta hook is `script/build-meta.sh`;
-    # pointers + abis use the upstream BuildPointers.sol convention.
+    # pointers + abis use the upstream Build.sol convention.
     uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ address + codehash. Do the whole cascade without asking:
 
 1. **Regenerate artifacts** — the canonical `rainix-copy-artifacts` sequence, in
    `nix develop github:rainlanguage/rainix#sol-shell`: `forge soldeer install` →
-   `script/build-meta.sh` → `forge script script/Build.sol` →
-   `forge build` → `forge script script/CopyArtifacts.sol --ffi` (if present) →
+   `script/build-meta.sh` → `forge script script/Build.sol` → `forge build` →
+   `forge script script/CopyArtifacts.sol --ffi` (if present) →
    `./script/build.sh` → `forge fmt`. Stage **all** changed artifacts (pointers,
    `crates/*/abis`, subgraph, meta) or `copy-artifacts` drifts red.
 2. **Deploy each changed suite**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ address + codehash. Do the whole cascade without asking:
 
 1. **Regenerate artifacts** — the canonical `rainix-copy-artifacts` sequence, in
    `nix develop github:rainlanguage/rainix#sol-shell`: `forge soldeer install` →
-   `script/build-meta.sh` → `forge script script/BuildPointers.sol` →
+   `script/build-meta.sh` → `forge script script/Build.sol` →
    `forge build` → `forge script script/CopyArtifacts.sol --ffi` (if present) →
    `./script/build.sh` → `forge fmt`. Stage **all** changed artifacts (pointers,
    `crates/*/abis`, subgraph, meta) or `copy-artifacts` drifts red.

--- a/foundry.toml
+++ b/foundry.toml
@@ -37,7 +37,7 @@ fs_permissions = [
   { access = "read-write", path = "./meta/RaindexV6SubParserAuthoringMeta.rain.meta" },
   { access = "read-write", path = "src/generated" },
   { access = "read", path = "./subgraph" },
-  # BuildPointers reads `[package].version` to name the frozen per-release snapshot dir.
+  # script/Build.sol reads `[package].version` to name the frozen per-release snapshot dir.
   { access = "read", path = "foundry.toml" },
 ]
 

--- a/script/Build.sol
+++ b/script/Build.sol
@@ -15,7 +15,7 @@ import {GenericPoolRaindexV6ArbOrderTaker} from "../src/concrete/arb/GenericPool
 import {RouteProcessorRaindexV6ArbOrderTaker} from "../src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol";
 import {GenericPoolRaindexV6FlashBorrower} from "../src/concrete/arb/GenericPoolRaindexV6FlashBorrower.sol";
 
-contract BuildPointers is Script {
+contract Build is Script {
     function addressConstantString(address addr) internal pure returns (string memory) {
         return string.concat(
             "\n",
@@ -186,7 +186,7 @@ contract BuildPointers is Script {
             if (vm.exists(frozenPath)) {
                 require(
                     keccak256(bytes(vm.readFile(frozenPath))) == keccak256(bytes(content)),
-                    "BuildPointers: frozen snapshot would change; bump [package].version for a new release"
+                    "Build: frozen snapshot would change; bump [package].version for a new release"
                 );
             }
             vm.writeFile(frozenPath, content);

--- a/test/util/abstract/RaindexV6FreshTest.sol
+++ b/test/util/abstract/RaindexV6FreshTest.sol
@@ -11,7 +11,7 @@ import {LibRaindexDeploy} from "../../../src/lib/deploy/LibRaindexDeploy.sol";
 /// FRESHLY COMPILED `RaindexV6` runtime bytecode at the deployed address rather
 /// than the committed `src/generated/RaindexV6.pointers.sol` runtime code that
 /// `LibEtchRaindex` etches. The committed pointers code is frozen at the last
-/// `BuildPointers.sol` run, so tests that run against it do not observe edits to
+/// `Build.sol` run, so tests that run against it do not observe edits to
 /// `src/concrete/raindex/RaindexV6.sol`. Overlaying `type(RaindexV6).runtimeCode`
 /// makes the live source the code under test.
 abstract contract RaindexV6FreshTest is RaindexV6ExternalRealTest {


### PR DESCRIPTION
rainlanguage/rainix#272 (merged, `ef89e90`) made `rainix-copy-artifacts` require the codegen script to be `script/Build.sol`, matched exactly. This repo's script is `script/BuildPointers.sol`, so its `copy-artifacts` job now **errors** until renamed.

That guard replaced an `if: hashFiles('script/BuildPointers.sol')` gate whose failure mode was worse than a red: a repo whose script didn't match that exact name had regeneration **silently skipped**, and the "committed artifacts match freshly built" assert then passed having regenerated nothing — a green over an unchecked tree.

## Change

- `script/BuildPointers.sol` -> `script/Build.sol`, `contract BuildPointers` -> `contract Build`.
- References to the script updated (docs, comments, and any invocation).

The generated `src/generated/*.pointers.sol` files are deliberately **untouched**. Their `AUTOGENERATED BY ./script/BuildPointers.sol` header is emitted by this repo's pinned `rain-sol-codegen`, which still writes that name, so regeneration reproduces them byte-for-byte and `copy-artifacts` stays green. The header and the `.pointers.sol` suffix change when this repo bumps to codegen 0.1.4+ (rainlanguage/rain.sol.codegen#31), which is separate work.

The name: the generated file is a set of constants for a contract, and only the interpreter/word repos generate an actual function pointer table — so "pointers" named the exception rather than the thing.
