### PR TITLE
feat: allow disabling local DB for registry clients

### DIFF
--- a/crates/common/src/raindex_client/mod.rs
+++ b/crates/common/src/raindex_client/mod.rs
@@ -133,6 +133,11 @@ impl RaindexClient {
     ///   localDb,
     ///   statusCallback: updateStatus,
     /// });
+    ///
+    /// // Ignore local-db-sync and use subgraphs only
+    /// const result = await RaindexClient.new([yamlConfig], undefined, {
+    ///   disableLocalDb: true,
+    /// });
     /// ```
     #[wasm_export(
         js_name = "new",
@@ -150,7 +155,7 @@ impl RaindexClient {
         validate: Option<bool>,
         #[wasm_export(
             js_name = "options",
-            param_description = "Optional setup object with localDb and statusCallback"
+            param_description = "Optional setup object with localDb, statusCallback, and disableLocalDb"
         )]
         options: Option<JsValue>,
     ) -> Result<RaindexClient, RaindexError> {
@@ -164,7 +169,10 @@ impl RaindexClient {
         )?;
         raindex_yaml.fetch_remote_data().await?;
 
-        let sync_configured_chains = LocalDbState::compute_chain_ids(&raindex_yaml);
+        let mut sync_configured_chains = LocalDbState::compute_chain_ids(&raindex_yaml);
+        if options.disable_local_db {
+            sync_configured_chains.clear();
+        }
         let sync_readiness = SyncReadiness::new();
         let sync_status_store = LocalDbSyncStatusStore::new();
         let has_syncs = !sync_configured_chains.is_empty();
@@ -233,6 +241,7 @@ impl RaindexClient {
 pub struct LocalDbClientOptions {
     pub local_db: Option<JsValue>,
     pub status_callback: Option<js_sys::Function>,
+    pub disable_local_db: bool,
 }
 
 #[cfg(target_family = "wasm")]
@@ -244,10 +253,12 @@ impl LocalDbClientOptions {
 
         let local_db = optional_field(&options, "localDb")?;
         let status_callback = optional_function_field(&options, "statusCallback")?;
+        let disable_local_db = optional_bool_field(&options, "disableLocalDb")?.unwrap_or(false);
 
         Ok(Self {
             local_db,
             status_callback,
+            disable_local_db,
         })
     }
 }
@@ -272,6 +283,19 @@ fn optional_function_field(
             value.dyn_into::<js_sys::Function>().map_err(|_| {
                 RaindexError::LocalDbQueryError(LocalDbQueryError::database(format!(
                     "options.{name} must be a function"
+                )))
+            })
+        })
+        .transpose()
+}
+
+#[cfg(target_family = "wasm")]
+fn optional_bool_field(options: &JsValue, name: &str) -> Result<Option<bool>, RaindexError> {
+    optional_field(options, name)?
+        .map(|value| {
+            value.as_bool().ok_or_else(|| {
+                RaindexError::LocalDbQueryError(LocalDbQueryError::database(format!(
+                    "options.{name} must be a boolean"
                 )))
             })
         })
@@ -1443,6 +1467,17 @@ raindexes:
             options.into()
         }
 
+        fn disable_local_db_options() -> JsValue {
+            let options = js_sys::Object::new();
+            js_sys::Reflect::set(
+                &options,
+                &JsValue::from_str("disableLocalDb"),
+                &JsValue::TRUE,
+            )
+            .unwrap();
+            options.into()
+        }
+
         #[wasm_bindgen_test]
         async fn test_raindex_client_new_success() {
             let client = RaindexClient::new(
@@ -1493,6 +1528,35 @@ raindexes:
             .unwrap();
 
             assert!(client.local_db_state.local_db().is_some());
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_raindex_client_new_can_disable_yaml_local_db_sync() {
+            let client = RaindexClient::new(
+                vec![local_db_sync_yaml()],
+                None,
+                Some(disable_local_db_options()),
+            )
+            .await
+            .unwrap();
+
+            assert!(client.local_db_state.local_db().is_none());
+            assert!(client.local_db_state.sync_configured_chains.is_empty());
+
+            let snapshot = client.get_local_db_sync_snapshot().await.unwrap();
+            assert!(!snapshot.configured);
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_raindex_client_new_requires_local_db_without_opt_out() {
+            let err = RaindexClient::new(vec![local_db_sync_yaml()], None, None)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(err, RaindexError::LocalDbSetupMissing(_)));
+            assert!(err
+                .to_readable_msg()
+                .contains("no options.localDb was provided"));
         }
 
         #[wasm_bindgen_test]

--- a/crates/js_api/src/registry.rs
+++ b/crates/js_api/src/registry.rs
@@ -395,6 +395,11 @@ impl DotrainRegistry {
     ///   localDb,
     ///   statusCallback: updateStatus,
     /// });
+    ///
+    /// // Keep the registry YAML unchanged but use subgraphs instead of local DB
+    /// const clientResult = await registry.getRaindexClient({
+    ///   disableLocalDb: true,
+    /// });
     /// if (clientResult.error) {
     ///   console.error("Failed to get RaindexClient:", clientResult.error.readableMsg);
     ///   return;
@@ -411,7 +416,7 @@ impl DotrainRegistry {
         &self,
         #[wasm_export(
             js_name = "options",
-            param_description = "Optional setup object with localDb and statusCallback"
+            param_description = "Optional setup object with localDb, statusCallback, and disableLocalDb"
         )]
         options: Option<JsValue>,
     ) -> Result<raindex_common::raindex_client::RaindexClient, DotrainRegistryError> {

--- a/packages/raindex/ARCHITECTURE.md
+++ b/packages/raindex/ARCHITECTURE.md
@@ -114,9 +114,10 @@ items:
   - `RaindexClient` — raindex queries (orders, trades, vaults, quotes,
     transactions) across configured networks/subgraphs. Constructor is async
     (`await RaindexClient.new(...)`) and accepts an optional
-    `{ localDb, statusCallback }` object for local DB sync when the YAML has
-    `local-db-sync` sections. The sync scheduler starts automatically when
-    configured and shuts down via Drop.
+    `{ localDb, statusCallback, disableLocalDb }` object. Local DB sync starts
+    automatically when the YAML has `local-db-sync` sections, unless the caller
+    explicitly sets `disableLocalDb: true` to use subgraphs without changing the
+    YAML. The sync scheduler shuts down via Drop.
   - `RaindexOrder`, `RaindexVault`, `RaindexTrade`, `RaindexTransaction`,
     `RaindexVaultsList`, etc.
   - `DotrainOrder`, `RaindexOrderBuilder`, `DotrainRegistry` — dotrain parsing,

--- a/packages/raindex/README.md
+++ b/packages/raindex/README.md
@@ -245,6 +245,16 @@ const clientResult = await RaindexClient.new([RAINDEX_SETTINGS], undefined, {
 The client will automatically start the sync scheduler and route queries to the
 local DB for configured chains once the first sync cycle completes.
 
+To consume the same canonical YAML without setting up a local database, opt out
+explicitly. The client leaves the YAML unchanged and routes queries through the
+configured subgraphs:
+
+```ts
+const clientResult = await RaindexClient.new([RAINDEX_SETTINGS], undefined, {
+  disableLocalDb: true,
+});
+```
+
 ### 2. Query orders with filters & pagination
 
 Here we scope the query by chain IDs and typical filters (owner, token, activity
@@ -646,6 +656,15 @@ const client = clientResult.value;
 const ordersResult = await client.getOrders([8453]);
 ```
 
+If the registry settings include `local-db-sync` but this consumer does not use
+a local database, pass the same opt-out to the registry helper:
+
+```ts
+const clientResult = await registry.getRaindexClient({
+  disableLocalDb: true,
+});
+```
+
 ### Build a deployment order builder
 
 Any dotrain file that includes a `builder:` block plus the usual settings YAML
@@ -882,7 +901,8 @@ if (!postTaskResult.error) console.log(postTaskResult.value);
 - Local DB sync – pass `{ localDb, statusCallback }` to `RaindexClient.new()`
   when YAML has `local-db-sync` sections to enable an offline-capable persistent
   cache. The scheduler starts automatically and queries route to the local DB
-  once the first sync cycle completes.
+  once the first sync cycle completes. Pass `{ disableLocalDb: true }` to keep
+  the same YAML but use subgraphs only.
 - `RaindexVaultsList.getWithdrawCalldata()` – multicall builder that withdraws
   every vault with a balance.
 - `RaindexOrder.convertToSgOrder()` – convert WASM order representations back

--- a/packages/raindex/test/js_api/dotrainRegistry.test.ts
+++ b/packages/raindex/test/js_api/dotrainRegistry.test.ts
@@ -626,5 +626,54 @@ test-order http://localhost:8231/order.rain`;
 
       assert.ok(raindexClient, "RaindexClient instance should be returned");
     });
+
+    it("should allow opting out of local DB configured by registry settings", async () => {
+      const registryContent = `http://localhost:8231/settings.yaml
+test-order http://localhost:8231/order.rain`;
+      const settingsWithLocalDbSync = `${MOCK_SETTINGS_CONTENT}
+local-db-remotes:
+  remote: https://example.com/local-db/manifest
+local-db-sync:
+  flare:
+    batch-size: 10
+    max-concurrent-batches: 2
+    retry-attempts: 1
+    retry-delay-ms: 1
+    rate-limit-delay-ms: 1
+    finality-depth: 12
+    bootstrap-block-threshold: 100
+    sync-interval-ms: 5000
+`;
+
+      await mockServer.forGet("/registry.txt").thenReply(200, registryContent);
+      await mockServer
+        .forGet("/settings.yaml")
+        .thenReply(200, settingsWithLocalDbSync);
+      await mockServer
+        .forGet("/order.rain")
+        .thenReply(200, MOCK_DOTRAIN_SIMPLE);
+
+      const registry = extractWasmEncodedData(
+        await DotrainRegistry.new("http://localhost:8231/registry.txt"),
+      );
+
+      const localDbRequiredResult = await registry.getRaindexClient();
+      assert.ok(localDbRequiredResult.error);
+      assert.ok(
+        localDbRequiredResult.error.readableMsg.includes(
+          "no options.localDb was provided",
+        ),
+      );
+
+      const raindexClient = extractWasmEncodedData(
+        await registry.getRaindexClient({ disableLocalDb: true }),
+      );
+      const snapshot = extractWasmEncodedData(
+        await raindexClient.getLocalDbSyncSnapshot(),
+      );
+
+      assert.ok(raindexClient, "RaindexClient instance should be returned");
+      assert.strictEqual(snapshot.configured, false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Canonical registry settings can include `local-db-sync` because the REST API uses the local database, while browser consumers of the same registry may be subgraph-only. Previously, `DotrainRegistry.getRaindexClient()` rejected that shared configuration unless the browser also supplied `options.localDb`.

- Add an explicit `{ disableLocalDb: true }` option to `RaindexClient.new()` and `DotrainRegistry.getRaindexClient()`.
- Keep the registry YAML unchanged while disabling the client's effective local DB sync chains, DB initialization, and scheduler startup, so queries use the configured subgraphs.
- Preserve existing behavior by default: YAML with `local-db-sync` still requires `options.localDb` unless the caller explicitly opts out.
- Document both direct-client and registry-client usage and cover the registry boundary with an integration test.

## Test

- `nix develop .#wasm-shell -c cargo check --target wasm32-unknown-unknown -p raindex_js_api`
- `nix develop .#wasm-shell -c npm run build -w @rainlanguage/raindex`
- `nix develop .#wasm-shell -c npm run test -w @rainlanguage/raindex` (125 tests passed)
- `nix develop .#wasm-shell -c rainix-rs-static`
- Commit hooks: denofmt, prettier-rainix, rustfmt, and applicable repository checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable local database synchronization when creating a client.
  * Disabled local database mode continues to support subgraph-based queries.
  * Registry-based client creation now supports the same opt-out option.

* **Bug Fixes**
  * Clients now clearly require local database configuration unless synchronization is explicitly disabled.

* **Documentation**
  * Updated setup guides, API references, and examples to explain local database opt-out behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->