### PR TITLE
ci: test npm trusted publishing on every push

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -1,12 +1,9 @@
 name: NPM Packages Release
-on:
-  push:
-    branches:
-      - main
+on: [push]
 jobs:
   release:
     # skip this job if the commit was created by this workflow (prevents infinite loop)
-    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'NPM Package Release') }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'NPM Package Release') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -275,11 +272,3 @@ jobs:
             ui_components_npm_package_${{ env.UC_NEW_VERSION }}.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # forwards status to telegram chat if this ci fails or gets canceled, only runs for default branch
-      - name: Forward CI Status
-        if: always()
-        uses: rainlanguage/github-chore/.github/actions/telegram-status-report@main
-        with:
-          status: ${{ job.status }}
-          telegram-bot-token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          telegram-chat-id: ${{ secrets.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
## Motivation

The npm package release workflow currently runs only after commits reach `main`, which makes the npm trusted-publisher configuration slow to diagnose. The latest release run received a GitHub OIDC token but npm rejected the exchange with `OIDC token exchange error - package not found`.

Both target packages already exist on npm at `0.0.1-alpha.238`:

- [`@rainlanguage/raindex`](https://www.npmjs.com/package/@rainlanguage/raindex)
- [`@rainlanguage/ui-components`](https://www.npmjs.com/package/@rainlanguage/ui-components)

This is a temporary diagnostic change. Once trusted publishing succeeds, the trigger should be restored to `main` only.

## Solution

- Run the real npm release workflow on every pushed commit on every branch.
- Preserve the generated release-commit guard so a successful release cannot trigger an infinite loop.
- Keep the existing GitHub OIDC permission and workflow filename unchanged.
- Remove Telegram status reporting while repeated diagnostic runs are expected.

The npm trusted publisher for each package should be configured for organization `rainlanguage`, repository `raindex`, and exact workflow filename `npm-package-release.yml`.

## Checks

- `git diff --check`
- Parsed `.github/workflows/npm-package-release.yml` with Ruby YAML
- Commit hooks passed, including `no-consumer-prettier` and `yamlfmt`
- Pushing this branch triggered the real npm release workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package release automation to run on all push events, while retaining safeguards against workflow-generated commits.
  * Removed automated CI failure and cancellation notifications sent to Telegram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->