### PR TITLE
chore: sync npm package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17585,7 +17585,7 @@
     },
     "packages/raindex": {
       "name": "@rainlanguage/raindex",
-      "version": "0.0.1-alpha.238",
+      "version": "0.0.1-alpha.239",
       "license": "LicenseRef-DCL-1.0",
       "dependencies": {
         "buffer": "6.0.3"
@@ -17699,14 +17699,14 @@
     },
     "packages/ui-components": {
       "name": "@rainlanguage/ui-components",
-      "version": "0.0.1-alpha.237",
+      "version": "0.0.1-alpha.238",
       "license": "LicenseRef-DCL-1.0",
       "dependencies": {
         "@codemirror/lang-yaml": "6.1.1",
         "@fontsource/dm-sans": "5.1.0",
         "@imask/svelte": "7.6.1",
         "@observablehq/plot": "0.6.16",
-        "@rainlanguage/raindex": "0.0.1-alpha.238",
+        "@rainlanguage/raindex": "0.0.1-alpha.239",
         "@reown/appkit": "1.6.4",
         "@reown/appkit-adapter-wagmi": "1.6.4",
         "@sentry/sveltekit": "7.120.0",

--- a/packages/raindex/package.json
+++ b/packages/raindex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rainlanguage/raindex",
   "description": "Provides RainLanguage Raindex rust crates' functionalities in typescript through wasm bindgen",
-  "version": "0.0.1-alpha.238",
+  "version": "0.0.1-alpha.239",
   "license": "LicenseRef-DCL-1.0",
   "author": "Rain Open Source Software Ltd",
   "repository": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rainlanguage/ui-components",
-	"version": "0.0.1-alpha.237",
+	"version": "0.0.1-alpha.238",
 	"description": "A component library for building Svelte applications to be used with Raindex.",
 	"license": "LicenseRef-DCL-1.0",
 	"author": "Rain Open Source Software Ltd",
@@ -57,7 +57,7 @@
 		"@fontsource/dm-sans": "5.1.0",
 		"@imask/svelte": "7.6.1",
 		"@observablehq/plot": "0.6.16",
-		"@rainlanguage/raindex": "0.0.1-alpha.238",
+		"@rainlanguage/raindex": "0.0.1-alpha.239",
 		"@reown/appkit": "1.6.4",
 		"@reown/appkit-adapter-wagmi": "1.6.4",
 		"@sentry/sveltekit": "7.120.0",


### PR DESCRIPTION
## Motivation

The npm release run successfully published `@rainlanguage/raindex@0.0.1-alpha.239`, then failed because `@rainlanguage/ui-components@0.0.1-alpha.238` was already published. The repository remained one version behind both registry versions, so rerunning the workflow unchanged would collide on the raindex version as well.

Failed run: https://github.com/rainlanguage/raindex/actions/runs/29427021691/job/88374580976

## Solution

- Synchronize the committed raindex version to `0.0.1-alpha.239`.
- Synchronize the committed UI-components version to `0.0.1-alpha.238`.
- Point UI components at raindex `0.0.1-alpha.239`.
- Update the corresponding workspace entries in `package-lock.json`.

## Checks

- Parsed the manifests and lockfile with Node and asserted all six version relationships.
- `git diff --check`
- Commit hooks passed, including `no-consumer-prettier` and `prettier-rainix`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Published updated alpha versions of the Raindex and UI components packages.
  * Updated the UI components package to depend on the latest Raindex alpha release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->