### PR TITLE
perf: prepare oracle quote contexts concurrently

### DIFF
--- a/crates/quote/src/oracle.rs
+++ b/crates/quote/src/oracle.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, Bytes, FixedBytes, U256};
 use alloy::sol_types::SolValue;
-use futures::{stream, StreamExt};
+use futures::{stream::FuturesUnordered, StreamExt};
 use once_cell::sync::{Lazy, OnceCell};
 use raindex_bindings::IRaindexV6::{OrderV4, SignedContextV1};
 use raindex_subgraph_client::types::common::SgOrder;
@@ -107,26 +107,23 @@ impl From<OracleResponse> for SignedContextV1 {
 pub(crate) struct OracleClient {
     client: Client,
     request_semaphores: Arc<OracleRequestSemaphores>,
-    // Consumed by the concurrent quote sweep in the immediately upstack PR.
-    #[allow(dead_code)]
     concurrency_limit: NonZeroUsize,
 }
 
-/// One independent oracle POST prepared for bounded execution.
-// Consumed by the concurrent quote sweep in the immediately upstack PR.
-#[allow(dead_code)]
-pub(crate) struct OracleRequest {
-    url: Url,
+/// One batch oracle POST prepared for bounded execution.
+pub(crate) struct OracleBatchRequest {
+    url: String,
     body: Vec<u8>,
+    expected_count: usize,
 }
 
-#[allow(dead_code)]
-impl OracleRequest {
-    pub(crate) fn new(url: String, body: Vec<u8>) -> Result<Self, OracleError> {
-        Ok(Self {
-            url: validate_oracle_url(&url)?,
+impl OracleBatchRequest {
+    pub(crate) fn new(url: String, body: Vec<u8>, expected_count: usize) -> Self {
+        Self {
+            url,
             body,
-        })
+            expected_count,
+        }
     }
 }
 
@@ -241,21 +238,23 @@ impl OracleClient {
         Ok(response.into())
     }
 
-    /// Fetch signed contexts for several independent pair requests.
+    /// Fetch signed contexts from several independent batch endpoints.
     ///
-    /// Results remain aligned with `requests`; a failed request is returned in
-    /// only its own slot. Requests run through the caller and per-origin
-    /// concurrency limits.
-    // Consumed by the concurrent quote sweep in the immediately upstack PR.
-    #[allow(dead_code)]
-    pub(crate) async fn fetch_signed_contexts(
+    /// Each request is one HTTP POST containing all pair requests for its exact
+    /// endpoint URL. Different endpoint batches execute concurrently through
+    /// the caller and per-origin limits, while results remain aligned with the
+    /// input batch order.
+    pub(crate) async fn fetch_signed_context_batches(
         &self,
-        requests: Vec<OracleRequest>,
-    ) -> Vec<Result<SignedContextV1, OracleError>> {
-        let requests = requests.into_iter().map(|request| async move {
-            self.fetch_signed_context_at(&request.url, request.body)
-                .await
-        });
+        requests: Vec<OracleBatchRequest>,
+    ) -> Vec<Result<Vec<SignedContextV1>, OracleError>> {
+        let requests = requests
+            .into_iter()
+            .map(|request| async move {
+                self.fetch_signed_context_batch(&request.url, request.body, request.expected_count)
+                    .await
+            })
+            .collect::<Vec<_>>();
 
         collect_bounded(requests, self.concurrency_limit).await
     }
@@ -287,23 +286,33 @@ fn build_http_client() -> Result<Client, reqwest::Error> {
     Client::builder().build()
 }
 
-// Consumed by the concurrent quote sweep in the immediately upstack PR.
-#[allow(dead_code)]
-async fn collect_bounded<F, T>(futures: impl IntoIterator<Item = F>, limit: NonZeroUsize) -> Vec<T>
+async fn collect_bounded<F, T>(futures: Vec<F>, limit: NonZeroUsize) -> Vec<T>
 where
     F: Future<Output = T>,
 {
-    let mut results = stream::iter(
-        futures
-            .into_iter()
-            .enumerate()
-            .map(|(index, future)| async move { (index, future.await) }),
-    )
-    .buffer_unordered(limit.get())
-    .collect::<Vec<_>>()
-    .await;
+    let mut pending = futures.into_iter().enumerate();
+    let mut in_flight = FuturesUnordered::new();
+    for (index, future) in pending.by_ref().take(limit.get()) {
+        in_flight.push(await_indexed(index, future));
+    }
+
+    let mut results = Vec::new();
+    while let Some(result) = in_flight.next().await {
+        results.push(result);
+        if let Some((index, future)) = pending.next() {
+            in_flight.push(await_indexed(index, future));
+        }
+    }
+
     results.sort_unstable_by_key(|(index, _)| *index);
     results.into_iter().map(|(_, result)| result).collect()
+}
+
+async fn await_indexed<F, T>(index: usize, future: F) -> (usize, T)
+where
+    F: Future<Output = T>,
+{
+    (index, future.await)
 }
 
 /// Encode the POST body for a single oracle request.
@@ -502,22 +511,19 @@ mod tests {
         mock.assert_async().await;
     }
 
-    #[test]
-    fn test_oracle_request_validates_url_at_construction() {
-        assert!(OracleRequest::new("not-a-url".to_owned(), vec![]).is_err());
-        assert!(
-            OracleRequest::new("https://oracle.example.com/context".to_owned(), vec![]).is_ok()
-        );
-    }
-
     #[cfg(not(target_family = "wasm"))]
     #[tokio::test]
-    async fn test_fetch_signed_contexts_preserves_request_positions_and_failures() {
+    async fn test_fetch_signed_context_batches_preserves_batch_positions_and_failures() {
         let server = MockServer::start_async().await;
         let first_response = OracleResponse {
             signer: address!("0x1111111111111111111111111111111111111111"),
             context: vec![FixedBytes::with_last_byte(1)],
             signature: vec![0xaa].into(),
+        };
+        let second_response = OracleResponse {
+            signer: address!("0x2222222222222222222222222222222222222222"),
+            context: vec![FixedBytes::with_last_byte(2)],
+            signature: vec![0xbb].into(),
         };
         let third_response = OracleResponse {
             signer: address!("0x3333333333333333333333333333333333333333"),
@@ -528,7 +534,7 @@ mod tests {
             .mock_async(|when, then| {
                 when.method(POST).path("/first");
                 then.status(200)
-                    .json_body_obj(&vec![first_response.clone()]);
+                    .json_body_obj(&vec![first_response.clone(), second_response.clone()]);
             })
             .await;
         let failing_mock = server
@@ -544,24 +550,29 @@ mod tests {
                     .json_body_obj(&vec![third_response.clone()]);
             })
             .await;
-        let requests = ["/first", "/failing", "/third"]
-            .into_iter()
-            .map(|path| OracleRequest::new(server.url(path), vec![]).unwrap())
-            .collect();
+        let requests = vec![
+            OracleBatchRequest::new(server.url("/first"), vec![], 2),
+            OracleBatchRequest::new(server.url("/failing"), vec![], 1),
+            OracleBatchRequest::new(server.url("/third"), vec![], 1),
+        ];
 
         let results = OracleClient::new()
             .unwrap()
-            .fetch_signed_contexts(requests)
+            .fetch_signed_context_batches(requests)
             .await;
 
         assert_eq!(results.len(), 3);
         assert_eq!(
-            results[0].as_ref().unwrap().signer,
+            results[0].as_ref().unwrap()[0].signer,
             address!("0x1111111111111111111111111111111111111111")
+        );
+        assert_eq!(
+            results[0].as_ref().unwrap()[1].signer,
+            address!("0x2222222222222222222222222222222222222222")
         );
         assert!(results[1].is_err());
         assert_eq!(
-            results[2].as_ref().unwrap().signer,
+            results[2].as_ref().unwrap()[0].signer,
             address!("0x3333333333333333333333333333333333333333")
         );
         first_mock.assert_async().await;
@@ -628,7 +639,8 @@ mod tests {
             }
         });
 
-        let results = collect_bounded(requests, NonZeroUsize::new(TEST_LIMIT).unwrap()).await;
+        let results =
+            collect_bounded(requests.collect(), NonZeroUsize::new(TEST_LIMIT).unwrap()).await;
 
         assert_eq!(maximum.load(Ordering::SeqCst), TEST_LIMIT);
         assert_eq!(started.load(Ordering::SeqCst), REQUEST_COUNT);
@@ -658,7 +670,7 @@ mod tests {
                 index
             }
         });
-        let results = collect_bounded(requests, NonZeroUsize::new(TEST_LIMIT).unwrap());
+        let results = collect_bounded(requests.collect(), NonZeroUsize::new(TEST_LIMIT).unwrap());
         tokio::pin!(results);
 
         tokio::select! {
@@ -726,7 +738,11 @@ mod tests {
             }
         });
 
-        collect_bounded(requests, NonZeroUsize::new(REQUEST_COUNT).unwrap()).await;
+        collect_bounded(
+            requests.collect(),
+            NonZeroUsize::new(REQUEST_COUNT).unwrap(),
+        )
+        .await;
 
         assert_eq!(
             maximum.load(Ordering::SeqCst),

--- a/crates/quote/src/order_quotes.rs
+++ b/crates/quote/src/order_quotes.rs
@@ -3,6 +3,7 @@ use crate::injector::NoopInjector;
 use crate::{
     error::Error,
     injector::SignedContextInjector,
+    oracle::{OracleBatchRequest, OracleClient, ORACLE_REQUEST_CONCURRENCY_LIMIT},
     quote::{BatchQuoteTarget, QuoteTarget},
     OrderQuoteValue,
 };
@@ -12,7 +13,7 @@ use raindex_bindings::provider::mk_read_provider;
 use raindex_bindings::IRaindexV6::{OrderV4, QuoteV2, SignedContextV1};
 use raindex_subgraph_client::types::common::SgOrder;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 use tracing::{debug, info, warn};
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_utils::prelude::js_sys::Date;
@@ -54,6 +55,26 @@ impl QuoteTiming {
     }
 }
 
+struct QuotePairPreparation {
+    pair: Pair,
+    quote_target: QuoteTarget,
+    oracle_url: Option<String>,
+}
+
+struct OracleBatchItem {
+    pair_preparation_index: usize,
+}
+
+struct OracleBatchPreparation {
+    url: String,
+    items: Vec<OracleBatchItem>,
+}
+
+struct QuotedPairMetadata {
+    slot_index: usize,
+    pair: Pair,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(target_family = "wasm", derive(Tsify))]
 #[serde(rename_all = "camelCase")]
@@ -92,12 +113,13 @@ impl_wasm_traits!(Pair);
 /// meta and appending any caller-supplied injector contexts.
 ///
 /// For each order, if the meta contains a `RaindexSignedContextOracleV1`
-/// entry, the oracle URL is extracted and signed context is fetched per IO
-/// pair via POST. Any additional entries produced by `injector` are appended
-/// after the oracle entries (composition order: `[oracle..., injected...]`),
-/// and the composed list is attached to the `QuoteV2.signedContext` before
-/// the multicall is issued. This matters for gated orders whose
-/// `calculate-io` asserts on signed context during quoting.
+/// entry, the oracle URL is extracted and every IO pair for the same exact URL
+/// is fetched in one batch POST. Different URL batches execute concurrently.
+/// Any additional entries produced by `injector` are appended after the oracle
+/// entries (composition order: `[oracle..., injected...]`), and the composed
+/// list is attached to the `QuoteV2.signedContext` before the multicall is
+/// issued. This matters for gated orders whose `calculate-io` asserts on
+/// signed context during quoting.
 pub async fn get_order_quotes(
     orders: Vec<SgOrder>,
     block_number: Option<u64>,
@@ -139,22 +161,15 @@ pub async fn get_order_quotes(
         "resolved quote block number"
     );
 
-    // Responses are assembled in strict iteration order. Pairs whose oracle
-    // fetch failed get a failure response stored immediately; quoted pairs
-    // leave a hole that is filled in after the RPC batch returns. This
-    // preserves per-order positional alignment for callers that re-slice the
-    // flat response vector by per-order pair counts.
-    let mut all_responses: Vec<Option<BatchOrderQuotesResponse>> = Vec::new();
-    // Parallel tracking for the subset of iteration slots that were quoted,
-    // so we can scatter RPC results back into `all_responses`.
-    let mut all_pairs: Vec<Pair> = Vec::new();
-    let mut all_quote_targets: Vec<QuoteTarget> = Vec::new();
-    let mut all_signed_contexts: Vec<Vec<SignedContextV1>> = Vec::new();
-    let mut quoted_slot_indices: Vec<usize> = Vec::new();
+    // Pair metadata is prepared in strict iteration order. Oracle pairs are
+    // grouped by exact endpoint URL so each endpoint receives one batch POST.
+    // Different endpoint batches execute concurrently below, then their
+    // results are scattered back into pair order before the batched chain
+    // quote.
+    let mut pair_preparations: Vec<QuotePairPreparation> = Vec::new();
+    let mut oracle_batches: Vec<OracleBatchPreparation> = Vec::new();
+    let mut oracle_batch_indices: HashMap<String, usize> = HashMap::new();
     let mut skipped_self_trade_pair_count = 0usize;
-    let mut oracle_fetch_count = 0usize;
-    let mut oracle_fetch_failure_count = 0usize;
-    let mut injected_context_count = 0usize;
 
     let target_build_started_at = QuoteTiming::now();
     for order in &orders {
@@ -195,100 +210,203 @@ pub async fn get_order_quotes(
                         .unwrap_or("UNKNOWN".to_string())
                 );
 
-                // Fetch signed oracle context for this pair if oracle URL is present.
-                // NOTE: Oracle context is always fetched live (current price), even when
-                // the quote is pinned to a historical block. This means historical quotes
-                // for oracle-backed orders reflect current oracle prices against past chain
-                // state, which may not represent a quote that actually existed.
-                let oracle_context = if let Some(ref url) = oracle_url {
-                    oracle_fetch_count += 1;
-                    let oracle_started_at = QuoteTiming::now();
-                    let body = crate::oracle::encode_oracle_body(
-                        &order_struct,
-                        input_index as u32,
-                        output_index as u32,
-                        counterparty,
-                    );
-                    match crate::oracle::fetch_signed_context(url, body).await {
-                        Ok(ctx) => {
-                            debug!(
-                                raindex = %raindex,
-                                input_index,
-                                output_index,
-                                duration_ms = oracle_started_at.elapsed_ms(),
-                                "fetched quote oracle context"
-                            );
-                            Ok(vec![ctx])
+                let pair_preparation_index = pair_preparations.len();
+                pair_preparations.push(QuotePairPreparation {
+                    pair: Pair {
+                        pair_name,
+                        input_index: input_index as u32,
+                        output_index: output_index as u32,
+                    },
+                    quote_target: QuoteTarget {
+                        raindex,
+                        quote_config: QuoteV2 {
+                            order: order_struct.clone(),
+                            inputIOIndex: U256::from(input_index),
+                            outputIOIndex: U256::from(output_index),
+                            signedContext: vec![],
+                        },
+                    },
+                    oracle_url: oracle_url.clone(),
+                });
+
+                // Oracle context remains live even when the quote is pinned to
+                // a historical block. All pairs sharing the exact configured
+                // endpoint URL are encoded into one request body below.
+                if let Some(url) = &oracle_url {
+                    let batch_index = match oracle_batch_indices.get(url) {
+                        Some(index) => *index,
+                        None => {
+                            let index = oracle_batches.len();
+                            oracle_batches.push(OracleBatchPreparation {
+                                url: url.clone(),
+                                items: Vec::new(),
+                            });
+                            oracle_batch_indices.insert(url.clone(), index);
+                            index
                         }
-                        Err(e) => {
-                            oracle_fetch_failure_count += 1;
-                            warn!(
-                                raindex = %raindex,
-                                input_index,
-                                output_index,
-                                duration_ms = oracle_started_at.elapsed_ms(),
-                                error = %e,
-                                "quote oracle context fetch failed"
-                            );
-                            Err(format!(
-                                "Oracle fetch failed for pair ({}, {}): {}",
-                                input_index, output_index, e
-                            ))
-                        }
-                    }
-                } else {
-                    Ok(vec![])
-                };
-
-                let pair = Pair {
-                    pair_name,
-                    input_index: input_index as u32,
-                    output_index: output_index as u32,
-                };
-
-                let slot_idx = all_responses.len();
-                match oracle_context {
-                    Ok(oracle_ctx) => {
-                        // Append injector-contributed contexts after the oracle
-                        // context. Gated orders that verify signed context by
-                        // index must know the composition order.
-                        let injected = injector
-                            .contexts_for(
-                                &order_struct,
-                                input_index as u32,
-                                output_index as u32,
-                                counterparty,
-                            )
-                            .await;
-                        injected_context_count += injected.len();
-                        let composed: Vec<SignedContextV1> =
-                            oracle_ctx.into_iter().chain(injected).collect();
-
-                        all_responses.push(None);
-                        all_pairs.push(pair);
-                        all_signed_contexts.push(composed.clone());
-                        all_quote_targets.push(QuoteTarget {
-                            raindex,
-                            quote_config: QuoteV2 {
-                                order: order_struct.clone(),
-                                inputIOIndex: U256::from(input_index),
-                                outputIOIndex: U256::from(output_index),
-                                signedContext: composed,
-                            },
-                        });
-                        quoted_slot_indices.push(slot_idx);
-                    }
-                    Err(e) => {
-                        all_responses.push(Some(BatchOrderQuotesResponse {
-                            pair,
-                            block_number: req_block_number,
-                            success: false,
-                            data: None,
-                            error: Some(e),
-                            signed_context: vec![],
-                        }));
-                    }
+                    };
+                    oracle_batches[batch_index].items.push(OracleBatchItem {
+                        pair_preparation_index,
+                    });
                 }
+            }
+        }
+    }
+
+    let oracle_fetch_count: usize = oracle_batches.iter().map(|batch| batch.items.len()).sum();
+    let oracle_batch_request_count = oracle_batches.len();
+    let oracle_batch_requests: Vec<OracleBatchRequest> = oracle_batches
+        .iter()
+        .map(|batch| {
+            let body = crate::oracle::encode_oracle_body_batch(
+                batch
+                    .items
+                    .iter()
+                    .map(|item| {
+                        let preparation = &pair_preparations[item.pair_preparation_index];
+                        (
+                            &preparation.quote_target.quote_config.order,
+                            preparation.pair.input_index,
+                            preparation.pair.output_index,
+                            counterparty,
+                        )
+                    })
+                    .collect(),
+            );
+            OracleBatchRequest::new(batch.url.clone(), body, batch.items.len())
+        })
+        .collect();
+    let oracle_fetch_started_at = QuoteTiming::now();
+    info!(
+        oracle_request_count = oracle_fetch_count,
+        oracle_endpoint_count = oracle_batch_request_count,
+        oracle_concurrency_limit = ORACLE_REQUEST_CONCURRENCY_LIMIT,
+        oracle_batch_request_count,
+        "starting bounded batched quote oracle context fetches"
+    );
+    let oracle_batch_results: Vec<Result<Vec<SignedContextV1>, String>> =
+        if oracle_batch_requests.is_empty() {
+            vec![]
+        } else {
+            match OracleClient::new() {
+                Ok(client) => client
+                    .fetch_signed_context_batches(oracle_batch_requests)
+                    .await
+                    .into_iter()
+                    .map(|result| result.map_err(|error| error.to_string()))
+                    .collect(),
+                Err(error) => {
+                    let error = error.to_string();
+                    (0..oracle_batch_request_count)
+                        .map(|_| Err(error.clone()))
+                        .collect()
+                }
+            }
+        };
+    let mut oracle_results: Vec<Option<Result<SignedContextV1, String>>> =
+        std::iter::repeat_with(|| None)
+            .take(pair_preparations.len())
+            .collect();
+    for (batch, batch_result) in oracle_batches.iter().zip(oracle_batch_results) {
+        match batch_result {
+            Ok(contexts) => {
+                for (item, context) in batch.items.iter().zip(contexts) {
+                    oracle_results[item.pair_preparation_index] = Some(Ok(context));
+                }
+            }
+            Err(error) => {
+                for item in &batch.items {
+                    oracle_results[item.pair_preparation_index] = Some(Err(error.clone()));
+                }
+            }
+        }
+    }
+    let oracle_fetch_failure_count = oracle_results
+        .iter()
+        .filter(|result| result.as_ref().is_some_and(Result::is_err))
+        .count();
+    info!(
+        oracle_request_count = oracle_fetch_count,
+        oracle_success_count = oracle_fetch_count.saturating_sub(oracle_fetch_failure_count),
+        oracle_failure_count = oracle_fetch_failure_count,
+        oracle_endpoint_count = oracle_batch_request_count,
+        oracle_batch_request_count,
+        oracle_concurrency_limit = ORACLE_REQUEST_CONCURRENCY_LIMIT,
+        duration_ms = oracle_fetch_started_at.elapsed_ms(),
+        "completed bounded batched quote oracle context fetches"
+    );
+
+    // Responses are assembled in strict iteration order. Pairs whose oracle
+    // fetch failed get a failure response stored immediately; quoted pairs
+    // leave a hole that is filled in after the RPC batch returns.
+    let mut all_responses: Vec<Option<BatchOrderQuotesResponse>> = Vec::new();
+    let mut all_quote_targets: Vec<QuoteTarget> = Vec::new();
+    let mut quoted_pair_metadata: Vec<QuotedPairMetadata> = Vec::new();
+    let mut injected_context_count = 0usize;
+
+    for (preparation, oracle_result) in pair_preparations.into_iter().zip(oracle_results) {
+        let oracle_context = if preparation.oracle_url.is_some() {
+            oracle_result
+                .unwrap_or_else(|| Err("Missing oracle response slot".to_string()))
+                .map(|context| vec![context])
+        } else {
+            Ok(vec![])
+        };
+        let input_index = preparation.pair.input_index;
+        let output_index = preparation.pair.output_index;
+        let raindex = preparation.quote_target.raindex;
+        let slot_idx = all_responses.len();
+
+        match oracle_context {
+            Ok(oracle_context) => {
+                if preparation.oracle_url.is_some() {
+                    debug!(
+                        raindex = %raindex,
+                        input_index,
+                        output_index,
+                        "fetched quote oracle context"
+                    );
+                }
+
+                let injected = injector
+                    .contexts_for(
+                        &preparation.quote_target.quote_config.order,
+                        input_index,
+                        output_index,
+                        counterparty,
+                    )
+                    .await;
+                injected_context_count += injected.len();
+                let composed: Vec<SignedContextV1> =
+                    oracle_context.into_iter().chain(injected).collect();
+                let mut quote_target = preparation.quote_target;
+                quote_target.quote_config.signedContext = composed;
+
+                all_responses.push(None);
+                quoted_pair_metadata.push(QuotedPairMetadata {
+                    slot_index: slot_idx,
+                    pair: preparation.pair,
+                });
+                all_quote_targets.push(quote_target);
+            }
+            Err(error) => {
+                warn!(
+                    raindex = %raindex,
+                    input_index,
+                    output_index,
+                    error = %error,
+                    "quote oracle context fetch failed"
+                );
+                all_responses.push(Some(BatchOrderQuotesResponse {
+                    pair: preparation.pair,
+                    block_number: req_block_number,
+                    success: false,
+                    data: None,
+                    error: Some(format!(
+                        "Oracle fetch failed for pair ({input_index}, {output_index}): {error}"
+                    )),
+                    signed_context: vec![],
+                }));
             }
         }
     }
@@ -305,10 +423,15 @@ pub async fn get_order_quotes(
     );
 
     let batch_quote_started_at = QuoteTiming::now();
-    let quote_results: Vec<BatchOrderQuotesResponse> = match BatchQuoteTarget(all_quote_targets)
+    let batch_quote_target = BatchQuoteTarget(all_quote_targets);
+    let quote_result = batch_quote_target
         .do_quote(rpcs, Some(req_block_number), counterparty, chunk_size)
-        .await
-    {
+        .await;
+    let signed_contexts = batch_quote_target
+        .0
+        .into_iter()
+        .map(|target| target.quote_config.signedContext);
+    let quote_results: Vec<(usize, BatchOrderQuotesResponse)> = match quote_result {
         Ok(quote_values) => {
             let failed_quote_count = quote_values.iter().filter(|result| result.is_err()).count();
             let successful_quote_count = quote_values.len().saturating_sub(failed_quote_count);
@@ -320,12 +443,11 @@ pub async fn get_order_quotes(
             );
             quote_values
                 .into_iter()
-                .zip(all_pairs)
-                .zip(all_signed_contexts)
-                .map(
-                    |((quote_result, pair), signed_context)| match quote_result {
+                .zip(quoted_pair_metadata.into_iter().zip(signed_contexts))
+                .map(|(quote_result, (metadata, signed_context))| {
+                    let response = match quote_result {
                         Ok(data) => BatchOrderQuotesResponse {
-                            pair,
+                            pair: metadata.pair,
                             block_number: req_block_number,
                             success: true,
                             data: Some(data),
@@ -333,42 +455,46 @@ pub async fn get_order_quotes(
                             signed_context,
                         },
                         Err(e) => BatchOrderQuotesResponse {
-                            pair,
+                            pair: metadata.pair,
                             block_number: req_block_number,
                             success: false,
                             data: None,
                             error: Some(e.to_string()),
                             signed_context,
                         },
-                    },
-                )
+                    };
+                    (metadata.slot_index, response)
+                })
                 .collect()
         }
         Err(e) => {
             let error = e.to_string();
             warn!(
-                quoted_pair_count = all_pairs.len(),
+                quoted_pair_count = quoted_pair_metadata.len(),
                 duration_ms = batch_quote_started_at.elapsed_ms(),
                 error = %error,
                 "quote batch RPC failed"
             );
-            all_pairs
+            quoted_pair_metadata
                 .into_iter()
-                .zip(all_signed_contexts)
-                .map(|(pair, signed_context)| BatchOrderQuotesResponse {
-                    pair,
-                    block_number: req_block_number,
-                    success: false,
-                    data: None,
-                    error: Some(error.clone()),
-                    signed_context,
+                .zip(signed_contexts)
+                .map(|(metadata, signed_context)| {
+                    let response = BatchOrderQuotesResponse {
+                        pair: metadata.pair,
+                        block_number: req_block_number,
+                        success: false,
+                        data: None,
+                        error: Some(error.clone()),
+                        signed_context,
+                    };
+                    (metadata.slot_index, response)
                 })
                 .collect()
         }
     };
 
     // Scatter quote results back into the iteration-ordered response vector.
-    for (slot_idx, response) in quoted_slot_indices.into_iter().zip(quote_results) {
+    for (slot_idx, response) in quote_results {
         all_responses[slot_idx] = Some(response);
     }
 
@@ -391,6 +517,8 @@ pub async fn get_order_quotes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(target_family = "wasm"))]
+    use alloy::primitives::{address, Bytes};
     use alloy::{
         hex::{encode_prefixed, FromHexError},
         primitives::B256,
@@ -398,6 +526,8 @@ mod tests {
         sol_types::{SolCall, SolValue},
     };
     use rain_math_float::Float;
+    #[cfg(not(target_family = "wasm"))]
+    use rain_metadata::types::raindex_signed_context_oracle::RaindexSignedContextOracleV1;
     use raindex_app_settings::spec_version::SpecVersion;
     use raindex_common::{add_order::AddOrderArgs, dotrain_order::DotrainOrder};
     use raindex_subgraph_client::types::{
@@ -406,6 +536,132 @@ mod tests {
     };
     use raindex_subgraph_client::utils::float::*;
     use raindex_test_fixtures::LocalEvm;
+    #[cfg(not(target_family = "wasm"))]
+    use serde_json::json;
+    #[cfg(not(target_family = "wasm"))]
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    #[cfg(not(target_family = "wasm"))]
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    #[cfg(not(target_family = "wasm"))]
+    struct TestInjector {
+        context: SignedContextV1,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[async_trait::async_trait]
+    impl SignedContextInjector for TestInjector {
+        async fn contexts_for(
+            &self,
+            _order: &OrderV4,
+            _input_io_index: u32,
+            _output_io_index: u32,
+            _counterparty: Address,
+        ) -> Vec<SignedContextV1> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            vec![self.context.clone()]
+        }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        let (body_start, content_length) = loop {
+            let mut chunk = [0u8; 4096];
+            let bytes_read = stream.read(&mut chunk).await.unwrap();
+            assert!(bytes_read > 0, "request ended before HTTP headers");
+            request.extend_from_slice(&chunk[..bytes_read]);
+
+            if let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                let body_start = header_end + 4;
+                let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap();
+                break (body_start, content_length);
+            }
+        };
+
+        while request.len() < body_start + content_length {
+            let mut chunk = [0u8; 4096];
+            let bytes_read = stream.read(&mut chunk).await.unwrap();
+            assert!(bytes_read > 0, "request ended before HTTP body");
+            request.extend_from_slice(&chunk[..bytes_read]);
+        }
+
+        request[body_start..body_start + content_length].to_vec()
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn start_batch_oracle_server(
+        responses: Vec<crate::oracle::OracleResponse>,
+    ) -> (String, tokio::task::JoinHandle<Vec<Vec<u8>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/oracle", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let body = read_http_body(&mut stream).await;
+            let payload = serde_json::to_vec(&responses).unwrap();
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                payload.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(&payload).await.unwrap();
+            vec![body]
+        });
+        (url, server)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn start_quote_rpc_server(
+        expected_calls: Vec<Bytes>,
+        result: String,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/rpc", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let body = read_http_body(&mut stream).await;
+            let request: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            let transaction = &request["params"][0];
+            let calldata = transaction
+                .get("input")
+                .or_else(|| transaction.get("data"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap();
+            let calldata = alloy::hex::decode(calldata).unwrap();
+            let multicall =
+                raindex_bindings::Raindex::multicallCall::abi_decode(&calldata).unwrap();
+            assert_eq!(multicall.data, expected_calls);
+
+            let payload = serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": request["id"].clone(),
+                "result": result,
+            }))
+            .unwrap();
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                payload.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(&payload).await.unwrap();
+        });
+        (url, server)
+    }
 
     struct TestSetup {
         local_evm: LocalEvm,
@@ -581,6 +837,13 @@ amount price: 2 3;
         }
     }
 
+    #[cfg(not(target_family = "wasm"))]
+    fn with_oracle_url(mut order: SgOrder, oracle_url: &str) -> SgOrder {
+        let oracle = RaindexSignedContextOracleV1::parse(oracle_url).unwrap();
+        order.meta = Some(SgBytes(encode_prefixed(oracle.cbor_encode().unwrap())));
+        order
+    }
+
     #[tokio::test]
     async fn test_get_order_quotes_ok() {
         let setup = setup_test().await;
@@ -695,6 +958,202 @@ amount price: 2 3;
                 expected_data.ratio.format().unwrap()
             );
         }
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn test_get_order_quotes_batches_oracle_results_and_preserves_alignment() {
+        let setup = setup_test().await;
+        let vault_id = B256::from(U256::from(1u64));
+        setup
+            .local_evm
+            .deposit(
+                setup.owner,
+                Address::from_str(&setup.token1.address.0).unwrap(),
+                U256::from(10).pow(U256::from(66)),
+                18,
+                vault_id,
+            )
+            .await;
+        setup
+            .local_evm
+            .deposit(
+                setup.owner,
+                Address::from_str(&setup.token2.address.0).unwrap(),
+                U256::from(10).pow(U256::from(66)),
+                18,
+                vault_id,
+            )
+            .await;
+
+        let order_bytes = create_order(&setup, create_dotrain_config(&setup)).await;
+        let vault1 = create_vault(vault_id, &setup, &setup.token1);
+        let vault2 = create_vault(vault_id, &setup, &setup.token2);
+        let inputs = vec![vault2.clone(), vault1.clone()];
+        let outputs = vec![vault2, vault1];
+        let oracle_contexts = [
+            SignedContextV1 {
+                signer: address!("0x1111111111111111111111111111111111111111"),
+                context: vec![B256::with_last_byte(1)],
+                signature: vec![0xaa].into(),
+            },
+            SignedContextV1 {
+                signer: address!("0x3333333333333333333333333333333333333333"),
+                context: vec![B256::with_last_byte(3)],
+                signature: vec![0xcc].into(),
+            },
+        ];
+        let oracle_responses = oracle_contexts
+            .iter()
+            .cloned()
+            .map(|context| crate::oracle::OracleResponse {
+                signer: context.signer,
+                context: context.context,
+                signature: context.signature,
+            })
+            .collect();
+        let base_oracle_order =
+            create_sg_order(&setup, order_bytes.clone(), inputs.clone(), outputs.clone());
+        let order_struct: OrderV4 = base_oracle_order.clone().try_into().unwrap();
+        let expected_oracle_body = crate::oracle::encode_oracle_body_batch(vec![
+            (&order_struct, 0, 1, Address::ZERO),
+            (&order_struct, 1, 0, Address::ZERO),
+        ]);
+        let (oracle_url, oracle_server) = start_batch_oracle_server(oracle_responses).await;
+        let oracle_order = with_oracle_url(base_oracle_order, &oracle_url);
+        let plain_order = create_sg_order(&setup, order_bytes, inputs, outputs);
+        let injected_context = SignedContextV1 {
+            signer: address!("0x2222222222222222222222222222222222222222"),
+            context: vec![B256::with_last_byte(2)],
+            signature: vec![0xbb].into(),
+        };
+        let injector_call_count = Arc::new(AtomicUsize::new(0));
+        let injector = TestInjector {
+            context: injected_context.clone(),
+            call_count: injector_call_count.clone(),
+        };
+        let quote_values =
+            [("2", "3"), ("4", "5"), ("6", "7"), ("8", "9")].map(|(output_max, ratio)| {
+                (
+                    Float::parse(output_max.to_string()).unwrap(),
+                    Float::parse(ratio.to_string()).unwrap(),
+                )
+            });
+        let quote_results = quote_values
+            .iter()
+            .map(|(output_max, ratio)| {
+                Bytes::from(
+                    raindex_bindings::IRaindexV6::quote2Call::abi_encode_returns(
+                        &raindex_bindings::IRaindexV6::quote2Return {
+                            exists: true,
+                            outputMax: output_max.get_inner(),
+                            ioRatio: ratio.get_inner(),
+                        },
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        let expected_oracle_quote_call = Bytes::from(
+            raindex_bindings::IRaindexV6::quote2Call {
+                quoteConfig: QuoteV2 {
+                    order: order_struct.clone(),
+                    inputIOIndex: U256::ZERO,
+                    outputIOIndex: U256::from(1),
+                    signedContext: vec![oracle_contexts[0].clone(), injected_context.clone()],
+                },
+            }
+            .abi_encode(),
+        );
+        let expected_second_oracle_quote_call = Bytes::from(
+            raindex_bindings::IRaindexV6::quote2Call {
+                quoteConfig: QuoteV2 {
+                    order: order_struct.clone(),
+                    inputIOIndex: U256::from(1),
+                    outputIOIndex: U256::ZERO,
+                    signedContext: vec![oracle_contexts[1].clone(), injected_context.clone()],
+                },
+            }
+            .abi_encode(),
+        );
+        let expected_plain_quote_call = Bytes::from(
+            raindex_bindings::IRaindexV6::quote2Call {
+                quoteConfig: QuoteV2 {
+                    order: order_struct.clone(),
+                    inputIOIndex: U256::ZERO,
+                    outputIOIndex: U256::from(1),
+                    signedContext: vec![injected_context.clone()],
+                },
+            }
+            .abi_encode(),
+        );
+        let expected_second_plain_quote_call = Bytes::from(
+            raindex_bindings::IRaindexV6::quote2Call {
+                quoteConfig: QuoteV2 {
+                    order: order_struct,
+                    inputIOIndex: U256::from(1),
+                    outputIOIndex: U256::ZERO,
+                    signedContext: vec![injected_context.clone()],
+                },
+            }
+            .abi_encode(),
+        );
+        let expected_rpc_calls = vec![
+            expected_oracle_quote_call,
+            expected_second_oracle_quote_call,
+            expected_plain_quote_call,
+            expected_second_plain_quote_call,
+        ];
+        let rpc_result = encode_prefixed(<Vec<Bytes> as SolValue>::abi_encode(&quote_results));
+        let (rpc_url, rpc_server) = start_quote_rpc_server(expected_rpc_calls, rpc_result).await;
+
+        let responses = get_order_quotes(
+            vec![oracle_order, plain_order],
+            Some(1),
+            vec![rpc_url],
+            None,
+            Address::ZERO,
+            &injector,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(responses.len(), 4);
+        assert_eq!(
+            responses
+                .iter()
+                .map(|response| response.success)
+                .collect::<Vec<_>>(),
+            vec![true, true, true, true]
+        );
+        assert_eq!(
+            responses
+                .iter()
+                .map(|response| (response.pair.input_index, response.pair.output_index))
+                .collect::<Vec<_>>(),
+            vec![(0, 1), (1, 0), (0, 1), (1, 0)]
+        );
+
+        for (response_index, quote_value_index) in [(0, 0), (1, 1), (2, 2), (3, 3)] {
+            let data = responses[response_index].data.as_ref().unwrap();
+            let (expected_output_max, expected_ratio) = &quote_values[quote_value_index];
+            assert!(data.max_output.eq(*expected_output_max).unwrap());
+            assert!(data.ratio.eq(*expected_ratio).unwrap());
+        }
+
+        for (response, oracle_context) in responses[..2].iter().zip(&oracle_contexts) {
+            assert_eq!(response.signed_context.len(), 2);
+            assert_eq!(response.signed_context[0].signer, oracle_context.signer);
+            assert_eq!(response.signed_context[1].signer, injected_context.signer);
+        }
+        for response in &responses[2..] {
+            assert_eq!(response.signed_context.len(), 1);
+            assert_eq!(response.signed_context[0].signer, injected_context.signer);
+        }
+
+        assert_eq!(injector_call_count.load(Ordering::SeqCst), 4);
+        let oracle_request_bodies = oracle_server.await.unwrap();
+        assert_eq!(oracle_request_bodies, vec![expected_oracle_body]);
+        rpc_server.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

Quote-target construction currently awaits each oracle POST inside the nested order/input/output loops. Production evidence from the st0x REST API showed about 49.6 oracle requests and about 9.7 seconds of target-build latency per cache miss, while the subsequent batched chain quote usually took only 100–600 ms.

## What changed

- prepare every valid pair and its established single-pair oracle request body in positional order
- execute oracle POSTs through the shared process-wide client with a conservative global concurrency limit of 8
- restore results to their original request slots before composing quote targets
- preserve oracle-before-injector signed-context order
- isolate an oracle error to only its corresponding pair response
- keep the chain quote as one `BatchQuoteTarget::do_quote` operation
- add tracing for oracle request, endpoint, success/failure, concurrency-limit, batching, and duration data
- add a deterministic end-to-end test that asserts exact oracle request bodies, partial failure isolation, exact ordered RPC multicall contents, signed-context composition, distinct RPC-result slot mapping, and a single chain RPC request

## Deliberate constraints

- The existing batch encoder/API is not used automatically because order metadata exposes only an oracle URL and does not declare that the configured endpoint accepts the batch ABI body.
- Requests remain individual POSTs and are bounded globally at 8; there is no unbounded fan-out.
- No retry/backoff was added because the endpoint contract does not declare POST idempotency. Existing 429/503 status handling remains a per-pair failure.
- Public response contracts, native/WASM support, timeout behavior, and chain RPC batching semantics are unchanged.

## Verification

- `cargo test -p raindex_quote --lib`
- `cargo clippy -p raindex_quote --all-targets --all-features -- -D warnings -D clippy::all`
- `cargo fmt --all -- --check`
- `nix develop .#wasm-shell -c bash -c 'CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --lib -p raindex_quote'`
- `nix develop .#wasm-shell -c rainix-rs-static`
- `git diff --check`

## Stack

Depends on #2825, which adds the reusable shared HTTP client and bounded ordered oracle-request primitive.
