### PR TITLE
Fix orders token filter source parity

### DIFF
--- a/crates/common/src/local_db/query/fetch_orders_common.rs
+++ b/crates/common/src/local_db/query/fetch_orders_common.rs
@@ -321,12 +321,13 @@ mod tests {
     // When input_tokens equals output_tokens, ONE EXISTS with OR-logic is
     // emitted (not two EXISTS), and the OUTPUT_TOKENS marker is removed.
     #[test]
-    fn identical_input_output_tokens_use_single_combined_exists() {
-        let t = address!("0x00000000000000000000000000000000000000aa");
+    fn canonical_equal_input_output_tokens_use_single_combined_exists() {
+        let a = address!("0x00000000000000000000000000000000000000aa");
+        let b = address!("0x00000000000000000000000000000000000000bb");
         let args = FetchOrdersArgs {
             tokens: FetchOrdersTokensFilter {
-                inputs: vec![t],
-                outputs: vec![t],
+                inputs: vec![b, a, a],
+                outputs: vec![a, b, b],
             },
             ..FetchOrdersArgs::default()
         };
@@ -343,12 +344,19 @@ mod tests {
         assert!(stmt.sql().contains("\n          OR\n"));
         assert!(!stmt.sql().contains(OUTPUT_TOKENS_CLAUSE));
         assert!(!stmt.sql().contains(INPUT_TOKENS_CLAUSE));
-        // Token bound twice (once per side of the OR).
-        let bound = text_params(&stmt)
-            .into_iter()
-            .filter(|s| s == "0x00000000000000000000000000000000000000aa")
-            .count();
-        assert_eq!(bound, 2);
+        // Each canonical token is bound once per side of the OR.
+        for token in [
+            "0x00000000000000000000000000000000000000aa",
+            "0x00000000000000000000000000000000000000bb",
+        ] {
+            assert_eq!(
+                text_params(&stmt)
+                    .into_iter()
+                    .filter(|bound| bound == token)
+                    .count(),
+                2
+            );
+        }
     }
 
     // Differing input/output token sets produce TWO separate directional EXISTS

--- a/crates/subgraph/src/raindex_client/order.rs
+++ b/crates/subgraph/src/raindex_client/order.rs
@@ -1,11 +1,102 @@
 use super::*;
-use alloy::{
-    hex,
-    primitives::{B256, U256},
-};
-use rain_math_float::Float;
+use crate::utils::float::F0;
+use alloy::{hex, primitives::B256};
+use std::collections::BTreeSet;
 
 impl RaindexSubgraphClient {
+    fn orders_list_filter(filter_args: SgOrdersListFilterArgs) -> Option<SgOrdersListQueryFilters> {
+        let tokens = filter_args.tokens.as_ref();
+        let input_tokens = tokens.map_or(&[][..], |tokens| tokens.inputs.as_slice());
+        let output_tokens = tokens.map_or(&[][..], |tokens| tokens.outputs.as_slice());
+        let has_input_tokens = !input_tokens.is_empty();
+        let has_output_tokens = !output_tokens.is_empty();
+        let has_positive_output_vault_balance =
+            filter_args.has_positive_output_vault_balance == Some(true);
+        let has_filters = !filter_args.owners.is_empty()
+            || filter_args.active.is_some()
+            || filter_args.order_hash.is_some()
+            || !filter_args.raindexes.is_empty()
+            || has_input_tokens
+            || has_output_tokens
+            || has_positive_output_vault_balance;
+
+        has_filters.then(|| {
+            let canonicalize = |tokens: &[String]| {
+                tokens
+                    .iter()
+                    .cloned()
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>()
+            };
+            let equal_tokens = if has_input_tokens && has_output_tokens {
+                if input_tokens == output_tokens {
+                    Some(canonicalize(input_tokens))
+                } else {
+                    let inputs = canonicalize(input_tokens);
+                    (inputs == canonicalize(output_tokens)).then_some(inputs)
+                }
+            } else {
+                None
+            };
+            let positive_vault_id = has_positive_output_vault_balance
+                .then(|| SgBytes(hex::encode_prefixed(B256::ZERO)));
+            let positive_balance = has_positive_output_vault_balance.then(|| SgBytes(F0.as_hex()));
+            let vault_filter = |token_in| SgVaultTokenFilter {
+                token_in,
+                vault_id_not: positive_vault_id.clone(),
+                balance_gt: positive_balance.clone(),
+            };
+            let common_filter = SgOrdersListQueryFilters {
+                owner_in: filter_args.owners,
+                active: filter_args.active,
+                order_hash: filter_args.order_hash,
+                outputs_: has_positive_output_vault_balance.then(|| vault_filter(vec![])),
+                raindex_in: filter_args.raindexes,
+                ..Default::default()
+            };
+
+            match equal_tokens {
+                None => {
+                    let directional_filter = SgOrdersListQueryFilters {
+                        inputs_: has_input_tokens.then(|| SgVaultTokenFilter {
+                            token_in: input_tokens.to_vec(),
+                            vault_id_not: None,
+                            balance_gt: None,
+                        }),
+                        ..common_filter
+                    };
+
+                    if has_output_tokens {
+                        SgOrdersListQueryFilters {
+                            outputs_: Some(vault_filter(output_tokens.to_vec())),
+                            ..directional_filter
+                        }
+                    } else {
+                        directional_filter
+                    }
+                }
+                Some(tokens) => SgOrdersListQueryFilters {
+                    or: Some(vec![
+                        SgOrdersListQueryFilters {
+                            inputs_: Some(SgVaultTokenFilter {
+                                token_in: tokens.clone(),
+                                vault_id_not: None,
+                                balance_gt: None,
+                            }),
+                            ..common_filter.clone()
+                        },
+                        SgOrdersListQueryFilters {
+                            outputs_: Some(vault_filter(tokens)),
+                            ..common_filter
+                        },
+                    ]),
+                    ..Default::default()
+                },
+            }
+        })
+    }
+
     /// Fetch single order
     pub async fn order_detail(&self, id: &Id) -> Result<SgOrder, RaindexSubgraphClientError> {
         let data = self
@@ -43,58 +134,10 @@ impl RaindexSubgraphClient {
     ) -> Result<Vec<SgOrder>, RaindexSubgraphClientError> {
         let pagination_variables = Self::parse_pagination_args(pagination_args);
 
-        let has_basic_filters = !filter_args.owners.is_empty()
-            || filter_args.active.is_some()
-            || filter_args.order_hash.is_some()
-            || !filter_args.raindexes.is_empty();
-        let tokens = filter_args.tokens.as_ref();
-        let has_input_tokens = tokens.is_some_and(|tokens| !tokens.inputs.is_empty());
-        let has_output_tokens = tokens.is_some_and(|tokens| !tokens.outputs.is_empty());
-        let has_token_filters = has_input_tokens || has_output_tokens;
-        let has_positive_output_vault_balance =
-            filter_args.has_positive_output_vault_balance == Some(true);
-
-        let filters = if has_basic_filters || has_token_filters || has_positive_output_vault_balance
-        {
-            let mut filters = SgOrdersListQueryFilters {
-                owner_in: filter_args.owners.clone(),
-                active: filter_args.active,
-                order_hash: filter_args.order_hash.clone(),
-                inputs_: None,
-                outputs_: None,
-                raindex_in: filter_args.raindexes.clone(),
-            };
-
-            if has_input_tokens {
-                let tokens = tokens.unwrap();
-                filters.inputs_ = Some(SgVaultTokenFilter {
-                    token_in: tokens.inputs.clone(),
-                    vault_id_not: None,
-                    balance_gt: None,
-                });
-            }
-            if has_output_tokens || has_positive_output_vault_balance {
-                let output_tokens = tokens
-                    .map(|tokens| tokens.outputs.clone())
-                    .unwrap_or_default();
-                filters.outputs_ = Some(SgVaultTokenFilter {
-                    token_in: output_tokens,
-                    vault_id_not: has_positive_output_vault_balance
-                        .then(|| SgBytes(hex::encode_prefixed(B256::from(U256::ZERO)))),
-                    balance_gt: has_positive_output_vault_balance
-                        .then(|| SgBytes(Float::zero().expect("zero float").as_hex())),
-                });
-            }
-
-            Some(filters)
-        } else {
-            None
-        };
-
         let variables = SgOrdersListQueryVariables {
             first: pagination_variables.first,
             skip: pagination_variables.skip,
-            filters,
+            filters: Self::orders_list_filter(filter_args),
         };
 
         let data = self
@@ -175,8 +218,7 @@ mod tests {
     use crate::types::common::{
         SgBigInt, SgBytes, SgOrder, SgOrdersListFilterArgs, SgOrdersTokensFilterArgs, SgRaindex,
     };
-    use crate::utils::float::*;
-    use cynic::Id;
+    use cynic::{Id, QueryBuilder};
     use httpmock::prelude::*;
     use rain_math_float::Float;
     use reqwest::Url;
@@ -185,6 +227,130 @@ mod tests {
     fn setup_client(server: &MockServer) -> RaindexSubgraphClient {
         let url = Url::parse(&server.url("")).unwrap();
         RaindexSubgraphClient::new(url)
+    }
+
+    #[test]
+    fn equal_token_sets_use_canonical_nested_or() {
+        let token_a = "0x00000000000000000000000000000000000000aa".to_string();
+        let token_b = "0x00000000000000000000000000000000000000bb".to_string();
+        let filters = RaindexSubgraphClient::orders_list_filter(SgOrdersListFilterArgs {
+            tokens: Some(SgOrdersTokensFilterArgs {
+                inputs: vec![token_b.clone(), token_a.clone(), token_a.clone()],
+                outputs: vec![token_a.clone(), token_b.clone(), token_b.clone()],
+            }),
+            ..default_filter_args()
+        })
+        .unwrap();
+
+        assert!(filters.inputs_.is_none());
+        assert!(filters.outputs_.is_none());
+        let or = filters.or.unwrap();
+        assert_eq!(or.len(), 2);
+        assert_eq!(
+            or[0].inputs_.as_ref().unwrap().token_in,
+            vec![token_a.clone(), token_b.clone()]
+        );
+        assert!(or[0].outputs_.is_none());
+        assert_eq!(
+            or[1].outputs_.as_ref().unwrap().token_in,
+            vec![token_a, token_b]
+        );
+        assert!(or[1].inputs_.is_none());
+    }
+
+    #[test]
+    fn one_sided_and_unequal_token_sets_remain_directional() {
+        let token_a = "0x00000000000000000000000000000000000000aa".to_string();
+        let token_b = "0x00000000000000000000000000000000000000bb".to_string();
+        let input_only = RaindexSubgraphClient::orders_list_filter(SgOrdersListFilterArgs {
+            tokens: Some(SgOrdersTokensFilterArgs {
+                inputs: vec![token_a.clone()],
+                outputs: vec![],
+            }),
+            ..default_filter_args()
+        })
+        .unwrap();
+
+        assert_eq!(
+            input_only.inputs_.as_ref().unwrap().token_in,
+            vec![token_a.clone()]
+        );
+        assert!(input_only.outputs_.is_none());
+        assert!(input_only.or.is_none());
+
+        let unequal = RaindexSubgraphClient::orders_list_filter(SgOrdersListFilterArgs {
+            tokens: Some(SgOrdersTokensFilterArgs {
+                inputs: vec![token_a.clone()],
+                outputs: vec![token_b.clone()],
+            }),
+            ..default_filter_args()
+        })
+        .unwrap();
+
+        assert_eq!(unequal.inputs_.as_ref().unwrap().token_in, vec![token_a]);
+        assert_eq!(unequal.outputs_.as_ref().unwrap().token_in, vec![token_b]);
+        assert!(unequal.or.is_none());
+    }
+
+    #[test]
+    fn equal_token_request_serializes_only_distributed_or_branches() {
+        let token = "0x00000000000000000000000000000000000000aa".to_string();
+        let owner = "0x00000000000000000000000000000000000000bb";
+        let order_hash = "0x00000000000000000000000000000000000000000000000000000000000000cc";
+        let raindex = "0x00000000000000000000000000000000000000dd";
+
+        let request_body = SgOrdersListQuery::build(SgOrdersListQueryVariables {
+            first: Some(10),
+            skip: Some(0),
+            filters: RaindexSubgraphClient::orders_list_filter(SgOrdersListFilterArgs {
+                owners: vec![SgBytes(owner.to_string())],
+                active: Some(true),
+                order_hash: Some(SgBytes(order_hash.to_string())),
+                tokens: Some(SgOrdersTokensFilterArgs {
+                    inputs: vec![token.clone()],
+                    outputs: vec![token],
+                }),
+                raindexes: vec![raindex.to_string()],
+                has_positive_output_vault_balance: Some(true),
+            }),
+        });
+        let request_body = serde_json::to_value(request_body).unwrap();
+        let filters = request_body["variables"]["filters"].as_object().unwrap();
+        assert_eq!(filters.len(), 1);
+        let branches = filters["or"].as_array().unwrap();
+        assert_eq!(branches.len(), 2);
+
+        for branch in branches {
+            assert_eq!(
+                branch["owner_in"],
+                json!(["0x00000000000000000000000000000000000000bb"])
+            );
+            assert_eq!(branch["active"], json!(true));
+            assert_eq!(
+                branch["orderHash"],
+                json!("0x00000000000000000000000000000000000000000000000000000000000000cc")
+            );
+            assert_eq!(
+                branch["raindex_in"],
+                json!(["0x00000000000000000000000000000000000000dd"])
+            );
+            assert_eq!(
+                branch["outputs_"]["vaultId_not"],
+                json!("0x0000000000000000000000000000000000000000000000000000000000000000")
+            );
+            assert_eq!(branch["outputs_"]["balance_gt"], json!(F0.as_hex()));
+        }
+
+        assert_eq!(
+            branches[0]["inputs_"]["token_in"],
+            json!(["0x00000000000000000000000000000000000000aa"])
+        );
+        assert!(branches[0]["outputs_"].get("token_in").is_none());
+        assert!(branches[1].get("inputs_").is_none());
+        assert_eq!(
+            branches[1]["outputs_"]["token_in"],
+            json!(["0x00000000000000000000000000000000000000aa"])
+        );
     }
 
     fn default_sg_order() -> SgOrder {

--- a/crates/subgraph/src/raindex_client/vault.rs
+++ b/crates/subgraph/src/raindex_client/vault.rs
@@ -24,12 +24,8 @@ impl RaindexSubgraphClient {
 
         let or = if filter_args.only_active_orders {
             let active_order_filter = SgOrdersListQueryFilters {
-                owner_in: vec![],
                 active: Some(true),
-                order_hash: None,
-                inputs_: None,
-                outputs_: None,
-                raindex_in: vec![],
+                ..Default::default()
             };
             Some(vec![
                 SgVaultsListQueryFilters {

--- a/crates/subgraph/src/types/common.rs
+++ b/crates/subgraph/src/types/common.rs
@@ -48,7 +48,7 @@ pub struct SgPaginationQueryVariables {
     pub skip: Option<i32>,
 }
 
-#[derive(cynic::InputObject, Debug, Clone, Tsify)]
+#[derive(cynic::InputObject, Debug, Clone, Tsify, Default)]
 #[cynic(graphql_type = "Order_filter")]
 pub struct SgOrdersListQueryFilters {
     #[cynic(rename = "owner_in", skip_serializing_if = "Vec::is_empty")]
@@ -63,6 +63,9 @@ pub struct SgOrdersListQueryFilters {
     pub outputs_: Option<SgVaultTokenFilter>,
     #[cynic(rename = "raindex_in", skip_serializing_if = "Vec::is_empty")]
     pub raindex_in: Vec<String>,
+    #[cynic(rename = "or", skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_family = "wasm", tsify(optional))]
+    pub or: Option<Vec<SgOrdersListQueryFilters>>,
 }
 
 #[derive(cynic::InputObject, Debug, Clone, Tsify)]


### PR DESCRIPTION
## Why

`GetOrdersFilters` currently has source-dependent semantics when both token lists are non-empty and represent the same set. The local SQLite query canonicalizes equal input/output sets and matches the token on either side, while the subgraph query puts `inputs_` and `outputs_` on one `Order_filter`, which GraphQL combines with AND.

A live Base (chain 8453) reproduction against the production registry and a fresh SQLite database isolated the mismatch:

- Directional USDC filters matched exactly across sources: active input-only 45/45, active output-only 48/48, all input-only 532/532, and all output-only 572/572, including order hashes.
- Equal USDC lists diverged: active subgraph/local DB 1/92 and all 7/1,097.
- Equal USDC+WETH lists also diverged: active 6/92 and all 74/1,098.

This blocks ST0x-Technology/st0x.rest.api#166, where omitted `side` intentionally maps to the same token set for inputs and outputs.

## What changed

- Exposed the pinned schema's recursive `or: [Order_filter]` field in `SgOrdersListQueryFilters`.
- Canonicalized non-empty input/output token sets by sorting and deduplicating before equality comparison.
- Emitted equal sets with `or` as the only top-level field, distributing owners, active, order hash, raindex, and positive output-vault balance into both branches to satisfy Goldsky's restriction against mixing column filters with `or`.
- Combined output-token membership and positive-balance fields in the output branch's single `outputs_` filter.
- Preserved one-sided filters and unequal two-sided directional AND filters.
- Added focused subgraph tests for reordered/duplicated equal sets, one-sided and unequal sets, plus a serialized request-level assertion covering the Goldsky-compatible OR shape with representative common filters and positive output balance.
- Strengthened the local DB test to lock the same reordered/duplicated canonical-set trigger.

## Intentionally unchanged

- Native local-DB readiness, query-source selection, and fallback policy.
- Pagination and unrelated SDK behavior.
- Downstream REST code and the st0x REST submodule pointer.
- No multi-query or N+1 workaround.

ST0x REST will update its submodule only after Arda evaluates and merges this upstream PR.

## Verification

- `cargo test -p raindex_subgraph_client`
- `cargo test -p raindex_common canonical_equal_input_output_tokens_use_single_combined_exists`
- `cargo test --workspace`
- `nix develop .#wasm-shell -c rainix-rs-static`
- Exact `wasm-test` workflow command for `raindex_quote`, `raindex_bindings`, `raindex_js_api`, and `raindex_common`
- Exact release-WASM artifact build for `raindex_js_api`
- Exact JS bindings workspace install/build/test workflow: 6 files and 124 tests passed
- `git diff --check main...HEAD`

## Reviewer focus

Please focus on the distributed OR composition: nothing except `or` may remain at the top level, every common filter must appear in both branches, and the output branch must combine token membership with positive output balance in one `outputs_` filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order filtering by consistently handling token lists regardless of ordering or duplicate entries.
  - Equal input and output token selections now match orders in either direction.
  - Preserved directional matching when token selections differ or only one side is specified.
  - Combined token filters now work correctly with owner, activity, hash, source, and balance filters.
  - Active-order filtering now returns only active orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->