### PR TITLE
Use generic numeric aliases for HyperRPC

### DIFF
--- a/crates/cli/src/commands/local_db/README.md
+++ b/crates/cli/src/commands/local_db/README.md
@@ -74,7 +74,7 @@ entire chain from genesis.
 
 - The command reports a per-raindex summary once all jobs finish; non-zero
   failures prevent manifest emission.
-- Supported chains are limited to those exposed by HyperRPC. Providing an
-  unsupported `chain-id` in the settings YAML will fail early.
+- HyperRPC endpoints use Envio's numeric chain-ID alias, so configured networks
+  do not require a matching hostname entry in the CLI.
 - Upload the generated `.sql.gz` files to the location represented by
   `--release-base-url` before distributing `manifest.yaml`.

--- a/crates/cli/src/commands/local_db/pipeline/runner/environment.rs
+++ b/crates/cli/src/commands/local_db/pipeline/runner/environment.rs
@@ -62,8 +62,7 @@ mod tests {
     use raindex_common::local_db::fetch::FetchConfig;
     use raindex_common::local_db::pipeline::engine::SyncInputs;
     use raindex_common::local_db::pipeline::{FinalityConfig, SyncConfig, WindowOverrides};
-    use raindex_common::local_db::{LocalDbError, RaindexIdentifier};
-    use raindex_common::rpc_client::RpcClientError;
+    use raindex_common::local_db::RaindexIdentifier;
     use url::Url;
 
     fn sample_target(chain_id: u32) -> RunnerTarget {
@@ -92,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    fn build_engine_configures_hyperrpc_for_supported_chain() {
+    fn build_engine_configures_hyperrpc_numeric_chain_alias() {
         let env = default_environment("super-secret-token".to_string(), DebugStatus::Disabled);
         let target = sample_target(42161);
         let engine = env.build_engine(&target).expect("engine available");
@@ -103,21 +102,22 @@ mod tests {
             "expected HyperRPC client for chain 42161: {events_debug}"
         );
         assert!(
-            events_debug.contains("https://arbitrum.rpc.hypersync.xyz"),
+            events_debug.contains("https://42161.rpc.hypersync.xyz/***"),
             "expected HyperRPC base URL in debug repr: {events_debug}"
+        );
+        assert!(
+            !events_debug.contains("super-secret-token"),
+            "expected HyperRPC API token to be redacted: {events_debug}"
         );
     }
 
     #[test]
-    fn build_engine_rejects_unsupported_chain() {
+    fn build_engine_accepts_previously_unlisted_chain() {
         let env = default_environment("token".to_string(), DebugStatus::Disabled);
         let target = sample_target(1);
-        match env.build_engine(&target) {
-            Err(LocalDbError::Rpc(RpcClientError::UnsupportedChainId { chain_id })) => {
-                assert_eq!(chain_id, 1);
-            }
-            Err(other) => panic!("unexpected error variant: {other:?}"),
-            Ok(_) => panic!("expected unsupported chain to fail"),
-        }
+        let engine = env.build_engine(&target).expect("engine available");
+
+        let events_debug = format!("{:?}", engine.events);
+        assert!(events_debug.contains("https://1.rpc.hypersync.xyz/***"));
     }
 }

--- a/crates/common/src/local_db/pipeline/adapters/events.rs
+++ b/crates/common/src/local_db/pipeline/adapters/events.rs
@@ -100,7 +100,7 @@ mod tests {
         let pipe = DefaultEventsPipeline::with_regular_rpcs(vec![test_url()])
             .expect("build with regular rpcs");
 
-        // with_hyperrpc (uses supported chain id; token string is arbitrary)
+        // with_hyperrpc (uses the numeric chain ID alias; token string is arbitrary)
         let _pipe3 = DefaultEventsPipeline::with_hyperrpc(42161, "token".to_string())
             .expect("build with hyperrpc");
         drop(pipe);
@@ -134,21 +134,10 @@ mod tests {
     }
 
     #[test]
-    fn constructor_error_paths() {
-        // Empty RPC list should error via RpcClient config mapping
+    fn with_regular_rpcs_rejects_empty_list() {
         let err = DefaultEventsPipeline::with_regular_rpcs(vec![]).expect_err("expected error");
         match err {
             LocalDbError::Rpc(RpcClientError::Config { .. }) => {}
-            other => panic!("unexpected error variant: {other:?}"),
-        }
-
-        // Unsupported chain id surfaces as Rpc -> UnsupportedChainId
-        let err = DefaultEventsPipeline::with_hyperrpc(9999, "token".to_string())
-            .expect_err("expected unsupported chain id error");
-        match err {
-            LocalDbError::Rpc(RpcClientError::UnsupportedChainId { chain_id }) => {
-                assert_eq!(chain_id, 9999);
-            }
             other => panic!("unexpected error variant: {other:?}"),
         }
     }

--- a/crates/common/src/rpc_client.rs
+++ b/crates/common/src/rpc_client.rs
@@ -92,14 +92,7 @@ impl RpcClient {
     }
 
     pub fn build_hyper_url(chain_id: u32, api_token: &str) -> Result<Url, RpcClientError> {
-        let base = match chain_id {
-            137 => "https://polygon.rpc.hypersync.xyz",
-            8453 => "https://base.rpc.hypersync.xyz",
-            42161 => "https://arbitrum.rpc.hypersync.xyz",
-            _ => return Err(RpcClientError::UnsupportedChainId { chain_id }),
-        };
-
-        let url = format!("{}/{}", base, api_token);
+        let url = format!("https://{chain_id}.rpc.hypersync.xyz/{api_token}");
         Ok(Url::parse(&url)?)
     }
 
@@ -306,28 +299,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_hyper_url_polygon_chain_id() {
-        let url = RpcClient::build_hyper_url(137, "test_token");
-        assert!(url.is_ok());
-        let url = url.unwrap().to_string();
-        assert!(url.contains("polygon.rpc.hypersync.xyz"));
-        assert!(url.contains("test_token"));
-    }
-
-    #[test]
-    fn test_build_hyper_url_supported_chain_id() {
-        let url = RpcClient::build_hyper_url(8453, "test_token");
-        assert!(url.is_ok());
-        assert!(url.unwrap().to_string().contains("test_token"));
-    }
-
-    #[test]
-    fn test_build_hyper_url_unsupported_chain_id() {
-        let url = RpcClient::build_hyper_url(9999, "test_token");
-        assert!(matches!(
-            url.unwrap_err(),
-            RpcClientError::UnsupportedChainId { chain_id: 9999 }
-        ));
+    fn test_build_hyper_url_uses_numeric_chain_id_alias() {
+        for chain_id in [1, 999, 8453, 9999] {
+            let url = RpcClient::build_hyper_url(chain_id, "test_token").unwrap();
+            assert_eq!(
+                url.as_str(),
+                format!("https://{chain_id}.rpc.hypersync.xyz/test_token")
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

Envio HyperRPC supports a generic numeric chain-ID alias. Using that alias removes the local network allowlist, so newly supported networks no longer require a code change just to add a hostname mapping.

## What changed

- Build HyperRPC endpoints as `https://{chain_id}.rpc.hypersync.xyz/{api_token}` for every numeric chain ID.
- Remove the Polygon, Base, and Arbitrum hostname match and its unsupported-chain rejection path.
- Cover Ethereum (`1`), HyperEVM (`999`), Base (`8453`), and a previously unlisted chain ID (`9999`) with deterministic URL tests.
- Update the producer integration tests to verify generic-chain acceptance and API-token redaction.
- Update the nearby LocalDB documentation to describe numeric aliases.

## Intentionally unchanged

- The public RPC client constructors and URL builder signatures are unchanged.
- The API token still comes from the existing external CLI/environment secret path.
- Debug output still redacts the API token.
- No network-specific special cases, credentials, paid URLs, or live paid-network tests were added.
- The public `UnsupportedChainId` error variant remains available for API compatibility, although generic alias construction no longer emits it.

## Verification

- `rainix-rs-static` (`cargo fmt --check` and Clippy with warnings denied)
- `cargo test --workspace`
- Exact `wasm-test` workflow command for `raindex_quote`, `raindex_bindings`, `raindex_js_api`, and `raindex_common`
- Release-WASM artifact build for `raindex_js_api`
- All six headless-Chrome `wasm-browser-test` workflow cases
- JS bindings build, TypeScript check, and Vitest suite: 124 tests passed
- Focused native tests for URL construction, common pipeline construction, CLI integration, and redaction
- Three-pass simplify review and a clean two-reviewer staged local review

## Risk and reviewer focus

An Envio-unsupported numeric chain ID now constructs the generic endpoint and fails when used remotely instead of being rejected by a local allowlist. That is intentional: Envio is the source of truth for supported chains, and future additions require no repository change. Reviewers should focus on the exact alias shape and preservation of token redaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HyperRPC now supports numeric chain-ID aliases for any network, including previously unsupported chains.
  * Local database pipelines can connect using numeric HyperSync URLs without matching CLI hostname entries.

* **Bug Fixes**
  * Improved configuration validation when no regular RPC endpoints are provided.
  * API tokens are now redacted in diagnostic output.

* **Documentation**
  * Updated local database setup guidance to reflect numeric chain-ID alias support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->