### PR TITLE
Fix take-order reselection after preflight failures

### DIFF
--- a/crates/common/src/raindex_client/take_orders/mod.rs
+++ b/crates/common/src/raindex_client/take_orders/mod.rs
@@ -16,9 +16,11 @@ pub use single::{build_candidate_from_quote, estimate_take_order, execute_single
 
 use super::{RaindexClient, RaindexError};
 use crate::rpc_client::RpcClient;
+use crate::take_orders::preflight::{diagnose_take_orders_failure, TakeOrdersFailureDiagnosis};
 use crate::take_orders::{
-    build_take_orders_config_from_simulation, find_failing_order_index, simulate_take_orders,
-    NoopInjector, SelectedTakeOrderLeg, SignedContextInjector,
+    build_take_orders_config_from_simulation, simulate_take_orders, BuiltTakeOrdersConfig,
+    NoopInjector, ParsedTakeOrdersMode, SelectedTakeOrderLeg, SignedContextInjector,
+    TakeOrderCandidate,
 };
 use crate::utils::timing::Timing;
 use alloy::primitives::{keccak256, B256};
@@ -76,6 +78,70 @@ fn format_float_for_log(value: rain_math_float::Float) -> String {
 
 fn order_hash_for_leg(leg: &SelectedTakeOrderLeg) -> B256 {
     B256::from(keccak256(leg.candidate.order.abi_encode()))
+}
+
+fn same_candidate(
+    left: &TakeOrderCandidate,
+    right: &TakeOrderCandidate,
+) -> Result<bool, RaindexError> {
+    Ok(left.raindex == right.raindex
+        && left.order == right.order
+        && left.input_io_index == right.input_io_index
+        && left.output_io_index == right.output_io_index
+        && left.signed_context == right.signed_context
+        && left.max_output.eq(right.max_output)?
+        && left.ratio.eq(right.ratio)?)
+}
+
+fn rebuild_without_failing_leg(
+    candidates: &mut Vec<TakeOrderCandidate>,
+    failing_leg: &SelectedTakeOrderLeg,
+    mode: ParsedTakeOrdersMode,
+    price_cap: rain_math_float::Float,
+) -> Result<Option<(alloy::primitives::Address, BuiltTakeOrdersConfig)>, RaindexError> {
+    let mut failing_candidate_index = None;
+    for (index, candidate) in candidates.iter().enumerate() {
+        if same_candidate(candidate, &failing_leg.candidate)? {
+            failing_candidate_index = Some(index);
+            break;
+        }
+    }
+    let failing_candidate_index = failing_candidate_index.ok_or_else(|| {
+        RaindexError::PreflightError(
+            "failing preflight candidate was not found in the remaining candidate set".to_string(),
+        )
+    })?;
+    candidates.remove(failing_candidate_index);
+
+    build_best_remaining_candidates(candidates, mode, price_cap)
+}
+
+fn rebuild_without_raindex(
+    candidates: &mut Vec<TakeOrderCandidate>,
+    failed_raindex: alloy::primitives::Address,
+    mode: ParsedTakeOrdersMode,
+    price_cap: rain_math_float::Float,
+) -> Result<Option<(alloy::primitives::Address, BuiltTakeOrdersConfig)>, RaindexError> {
+    candidates.retain(|candidate| candidate.raindex != failed_raindex);
+    build_best_remaining_candidates(candidates, mode, price_cap)
+}
+
+fn build_best_remaining_candidates(
+    candidates: &[TakeOrderCandidate],
+    mode: ParsedTakeOrdersMode,
+    price_cap: rain_math_float::Float,
+) -> Result<Option<(alloy::primitives::Address, BuiltTakeOrdersConfig)>, RaindexError> {
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let (raindex, simulation) =
+        selection::select_best_raindex_simulation(candidates.to_vec(), mode, price_cap)?;
+
+    Ok(
+        build_take_orders_config_from_simulation(simulation, mode, price_cap)?
+            .map(|built| (raindex, built)),
+    )
 }
 
 fn log_selected_leg(
@@ -254,11 +320,11 @@ impl RaindexClient {
         .await?;
         let candidates_count = candidates.len();
 
-        let (best_raindex, best_sim) = {
+        let (mut best_raindex, best_sim) = {
             let _span = info_span!("take_orders.selecting_best_raindex").entered();
             selection::select_best_raindex_simulation(candidates.clone(), req.mode, req.price_cap)?
         };
-        let selected_legs_count = best_sim.legs.len();
+        let mut remaining_candidates = candidates;
 
         let mut built = {
             let _span = info_span!("take_orders.building_config", raindex = %best_raindex).entered();
@@ -278,40 +344,44 @@ impl RaindexClient {
             "selected take-orders candidate leg",
         );
 
-        let approval_params = ApprovalCheckParams {
-            rpc_urls: rpc_urls.clone(),
-            sell_token: req.sell_token,
-            taker: req.taker,
-            raindex: best_raindex,
-            mode: req.mode,
-            price_cap: req.price_cap,
-        };
-
-        if let Some(approval_result) = check_approval_needed(&approval_params)
-            .instrument(info_span!("take_orders.checking_approval", raindex = %best_raindex))
-            .await?
-        {
-            info!(
-                result_type = "approval_required",
-                orders_count,
-                candidates_count,
-                selected_raindex = %best_raindex,
-                selected_legs_count,
-                block_number,
-                preflight_iterations = 0usize,
-                removed_orders_count = 0usize,
-                duration_ms = started_at.elapsed_ms(),
-                "take-orders calldata requires approval"
-            );
-            return Ok(approval_result);
-        }
-
         let provider =
             mk_read_provider(&rpc_urls).map_err(|e| RaindexError::PreflightError(e.to_string()))?;
 
         let mut removed_orders_count = 0usize;
-        let max_iterations = built.config.orders.len();
+        let mut skipped_raindexes_count = 0usize;
+        let mut approval_checked_raindex = None;
+        let max_iterations = remaining_candidates.len();
         for iteration in 0..max_iterations {
+            if approval_checked_raindex != Some(best_raindex) {
+                let approval_params = ApprovalCheckParams {
+                    rpc_urls: rpc_urls.clone(),
+                    sell_token: req.sell_token,
+                    taker: req.taker,
+                    raindex: best_raindex,
+                    mode: req.mode,
+                    price_cap: req.price_cap,
+                };
+                if let Some(approval_result) = check_approval_needed(&approval_params)
+                    .instrument(info_span!("take_orders.checking_approval", raindex = %best_raindex))
+                    .await?
+                {
+                    info!(
+                        result_type = "approval_required",
+                        orders_count,
+                        candidates_count,
+                        selected_raindex = %best_raindex,
+                        selected_legs_count = built.sim.legs.len(),
+                        block_number,
+                        preflight_iterations = iteration,
+                        removed_orders_count,
+                        duration_ms = started_at.elapsed_ms(),
+                        "take-orders calldata requires approval"
+                    );
+                    return Ok(approval_result);
+                }
+                approval_checked_raindex = Some(best_raindex);
+            }
+
             let iteration_started_at = Timing::now();
             let sim_result = simulate_take_orders(
                 &provider,
@@ -347,6 +417,7 @@ impl RaindexClient {
                         block_number,
                         preflight_iterations = iteration + 1,
                         removed_orders_count,
+                        skipped_raindexes_count,
                         duration_ms = started_at.elapsed_ms(),
                         "take-orders calldata ready"
                     );
@@ -368,7 +439,7 @@ impl RaindexClient {
                         duration_ms = iteration_started_at.elapsed_ms(),
                         "preflight simulation failed"
                     );
-                    if let Some(failing_idx) = find_failing_order_index(
+                    let diagnosis = diagnose_take_orders_failure(
                         &provider,
                         best_raindex,
                         req.taker,
@@ -383,23 +454,43 @@ impl RaindexClient {
                         order_count = built.config.orders.len(),
                         iteration
                     ))
-                    .await
-                    {
-                        if built.config.orders.len() <= 1 {
-                            error!(
-                                raindex = %best_raindex,
-                                iteration,
-                                failing_order_index = failing_idx,
-                                error = %truncate_error(&sim_error),
-                                "all orders failed preflight simulation"
+                    .await;
+                    match diagnosis {
+                        TakeOrdersFailureDiagnosis::Recovered => {
+                            log_selected_legs(
+                                best_raindex,
+                                block_number,
+                                &built.sim.legs,
+                                "final take-orders transaction leg",
                             );
-                            return Err(RaindexError::PreflightError(format!(
-                                "All orders failed simulation. Last error: {}",
-                                sim_error
-                            )));
+                            info!(
+                                result_type = "take_orders",
+                                orders_count,
+                                candidates_count,
+                                selected_raindex = %best_raindex,
+                                selected_legs_count = built.sim.legs.len(),
+                                block_number,
+                                preflight_iterations = iteration + 1,
+                                removed_orders_count,
+                                skipped_raindexes_count,
+                                duration_ms = started_at.elapsed_ms(),
+                                "take-orders calldata ready after recovered preflight"
+                            );
+                            return result::build_calldata_result(
+                                best_raindex,
+                                built,
+                                req.mode,
+                                req.price_cap,
+                            );
                         }
-
-                        if let Some(failing_leg) = built.sim.legs.get(failing_idx) {
+                        TakeOrdersFailureDiagnosis::FailingOrder(failing_idx) => {
+                            let failed_raindex = best_raindex;
+                            let failing_leg =
+                                built.sim.legs.get(failing_idx).ok_or_else(|| {
+                                    RaindexError::PreflightError(format!(
+                                        "failing order index {failing_idx} has no matching simulation leg"
+                                    ))
+                                })?;
                             warn_selected_leg(
                                 failing_idx,
                                 failing_leg,
@@ -407,30 +498,85 @@ impl RaindexClient {
                                 block_number,
                                 "removed failing preflight leg",
                             );
-                        }
 
-                        built.config.orders.remove(failing_idx);
-                        built.sim.legs.remove(failing_idx);
-                        removed_orders_count += 1;
-                        warn!(
-                            raindex = %best_raindex,
-                            iteration,
-                            failing_order_index = failing_idx,
-                            orders_remaining = built.config.orders.len(),
-                            removed_orders_count,
-                            "removed failing order after preflight"
-                        );
-                    } else {
-                        error!(
-                            raindex = %best_raindex,
-                            iteration,
-                            error = %truncate_error(&sim_error),
-                            "preflight failed without identifiable order"
-                        );
-                        return Err(RaindexError::PreflightError(format!(
-                            "Simulation failed but could not identify failing order: {}",
-                            sim_error
-                        )));
+                            removed_orders_count += 1;
+                            let rebuilt = rebuild_without_failing_leg(
+                                &mut remaining_candidates,
+                                failing_leg,
+                                req.mode,
+                                req.price_cap,
+                            )?;
+                            let Some((rebuilt_raindex, rebuilt)) = rebuilt else {
+                                error!(
+                                    raindex = %best_raindex,
+                                    iteration,
+                                    failing_order_index = failing_idx,
+                                    error = %truncate_error(&sim_error),
+                                    "all orders failed preflight simulation"
+                                );
+                                return Err(RaindexError::PreflightError(format!(
+                                    "All orders failed simulation. Last error: {}",
+                                    sim_error
+                                )));
+                            };
+                            best_raindex = rebuilt_raindex;
+                            built = rebuilt;
+                            warn!(
+                                failed_raindex = %failed_raindex,
+                                selected_raindex = %best_raindex,
+                                iteration,
+                                failing_order_index = failing_idx,
+                                orders_remaining = built.config.orders.len(),
+                                candidates_remaining = remaining_candidates.len(),
+                                removed_orders_count,
+                                "rebuilt take-orders config after removing failing order"
+                            );
+                            log_selected_legs(
+                                best_raindex,
+                                block_number,
+                                &built.sim.legs,
+                                "reselected take-orders candidate leg",
+                            );
+                        }
+                        TakeOrdersFailureDiagnosis::Unidentified => {
+                            let failed_raindex = best_raindex;
+                            let rebuilt = rebuild_without_raindex(
+                                &mut remaining_candidates,
+                                failed_raindex,
+                                req.mode,
+                                req.price_cap,
+                            )?;
+                            let Some((rebuilt_raindex, rebuilt)) = rebuilt else {
+                                error!(
+                                    raindex = %failed_raindex,
+                                    iteration,
+                                    error = %truncate_error(&sim_error),
+                                    "preflight failed without identifiable order or fallback raindex"
+                                );
+                                return Err(RaindexError::PreflightError(format!(
+                                    "Simulation failed but could not identify failing order: {}",
+                                    sim_error
+                                )));
+                            };
+                            skipped_raindexes_count += 1;
+                            best_raindex = rebuilt_raindex;
+                            built = rebuilt;
+                            warn!(
+                                failed_raindex = %failed_raindex,
+                                selected_raindex = %best_raindex,
+                                iteration,
+                                error = %truncate_error(&sim_error),
+                                candidates_remaining = remaining_candidates.len(),
+                                skipped_raindexes_count,
+                                "skipped raindex after aggregate preflight failure"
+                            );
+                            log_selected_legs(
+                                best_raindex,
+                                block_number,
+                                &built.sim.legs,
+                                "reselected take-orders candidate leg",
+                            );
+                        }
                     }
                 }
             }
@@ -440,6 +586,7 @@ impl RaindexClient {
             raindex = %best_raindex,
             max_iterations,
             removed_orders_count,
+            skipped_raindexes_count,
             "exceeded maximum preflight iterations"
         );
             Err(RaindexError::PreflightError(
@@ -454,6 +601,309 @@ impl RaindexClient {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_family = "wasm"))]
+    mod native_tests {
+        use super::super::*;
+        use crate::take_orders::{simulate_candidates, TakeOrdersMode};
+        use crate::test_helpers::candidates::make_candidate;
+        use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+        use rain_math_float::Float;
+        use raindex_bindings::IRaindexV6::SignedContextV1;
+
+        fn float(value: &str) -> Float {
+            Float::parse(value.to_string()).unwrap()
+        }
+
+        fn candidate(max_output: &str, ratio: &str, nonce: u64) -> TakeOrderCandidate {
+            let mut candidate =
+                make_candidate(Address::from([0x11u8; 20]), float(max_output), float(ratio));
+            candidate.order.nonce = U256::from(nonce).into();
+            candidate
+        }
+
+        fn mode(mode: TakeOrdersMode, amount: &str) -> ParsedTakeOrdersMode {
+            ParsedTakeOrdersMode {
+                mode,
+                amount: float(amount),
+            }
+        }
+
+        fn signed_context(value: u8) -> SignedContextV1 {
+            SignedContextV1 {
+                signer: Address::from([value; 20]),
+                context: vec![FixedBytes::<32>::from(
+                    U256::from(value).to_be_bytes::<32>(),
+                )],
+                signature: Bytes::from(vec![value]),
+            }
+        }
+
+        #[test]
+        fn rebuild_updates_partial_spend_totals_after_removal() {
+            let candidates = vec![candidate("5", "1", 1), candidate("7.5", "2", 2)];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+            assert!(initial.total_input.eq(float("20")).unwrap());
+
+            let mut remaining = candidates;
+            let rebuilt =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap()
+                    .1;
+
+            assert_eq!(rebuilt.sim.legs.len(), 1);
+            assert_eq!(rebuilt.config.orders.len(), 1);
+            assert!(rebuilt.sim.total_input.eq(float("15")).unwrap());
+            assert!(rebuilt.sim.total_output.eq(float("7.5")).unwrap());
+
+            let result = result::build_calldata_result(
+                Address::from([0x11u8; 20]),
+                rebuilt,
+                mode,
+                price_cap,
+            )
+            .unwrap();
+            assert!(result
+                .take_orders_info()
+                .unwrap()
+                .expected_sell()
+                .eq(float("15"))
+                .unwrap());
+        }
+
+        #[test]
+        fn rebuild_reports_incident_executable_total_after_removal() {
+            let failing_output =
+                "0.9190873838009207986009475041066889213119489421507552037575367421589";
+            let failing_ratio =
+                "0.007502722698831713208597944445410618026068357798898643535155918523172";
+            let executable_output =
+                "4.142551979932675829857451653658053577877751406982938626050220986676";
+            let executable_ratio =
+                "0.010405262850569590820343337005442828611770549820812206944645896242997";
+            let candidates = vec![
+                candidate(failing_output, failing_ratio, 1),
+                candidate(executable_output, executable_ratio, 2),
+            ];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "0.05");
+            let price_cap =
+                float("0.010507140312878644839541586318708372026337414326508889434455784294694");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+            assert!(initial.total_input.lt(float("0.05")).unwrap());
+            assert!(initial.total_input.gt(float("0.049")).unwrap());
+
+            let mut remaining = candidates;
+            let rebuilt =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap()
+                    .1;
+            let rebuilt_total_input = rebuilt.sim.total_input;
+            let result = result::build_calldata_result(
+                Address::from([0x11u8; 20]),
+                rebuilt,
+                mode,
+                price_cap,
+            )
+            .unwrap();
+            let expected_sell = result.take_orders_info().unwrap().expected_sell();
+
+            assert!(expected_sell.eq(rebuilt_total_input).unwrap());
+            assert!(expected_sell.gt(float("0.043")).unwrap());
+            assert!(expected_sell.lt(float("0.044")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_selects_previously_unused_fallback_candidate() {
+            let candidates = vec![candidate("20", "1", 1), candidate("20", "2", 2)];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+            assert_eq!(initial.legs.len(), 1);
+
+            let mut remaining = candidates;
+            let rebuilt =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap()
+                    .1;
+
+            assert_eq!(rebuilt.sim.legs.len(), 1);
+            assert!(rebuilt.sim.total_input.eq(float("20")).unwrap());
+            assert!(rebuilt.sim.total_output.eq(float("10")).unwrap());
+            assert!(rebuilt.sim.legs[0].candidate.ratio.eq(float("2")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_removes_only_candidate_with_matching_signed_context() {
+            let mut failing = candidate("20", "1", 1);
+            failing.signed_context = vec![signed_context(1)];
+            let mut fallback = failing.clone();
+            fallback.ratio = float("2");
+            fallback.signed_context = vec![signed_context(2)];
+            let candidates = vec![failing, fallback];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+
+            let mut remaining = candidates;
+            let rebuilt =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap()
+                    .1;
+
+            assert_eq!(remaining.len(), 1);
+            assert_eq!(remaining[0].signed_context, vec![signed_context(2)]);
+            assert_eq!(rebuilt.sim.legs.len(), 1);
+            assert!(rebuilt.sim.legs[0].candidate.ratio.eq(float("2")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_removes_only_matching_quote_for_same_executable_order() {
+            let failing = candidate("20", "1", 1);
+            let mut fallback = failing.clone();
+            fallback.max_output = float("10");
+            fallback.ratio = float("2");
+            let candidates = vec![failing, fallback];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+
+            let mut remaining = candidates;
+            let (_, rebuilt) =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap();
+
+            assert_eq!(remaining.len(), 1);
+            assert!(remaining[0].max_output.eq(float("10")).unwrap());
+            assert!(remaining[0].ratio.eq(float("2")).unwrap());
+            assert_eq!(rebuilt.sim.legs.len(), 1);
+        }
+
+        #[test]
+        fn rebuild_updates_partial_buy_totals_after_removal() {
+            let candidates = vec![candidate("5", "1", 1), candidate("15", "2", 2)];
+            let mode = mode(TakeOrdersMode::BuyUpTo, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+            assert!(initial.total_output.eq(float("20")).unwrap());
+
+            let mut remaining = candidates;
+            let rebuilt =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap()
+                    .1;
+
+            assert!(rebuilt.sim.total_input.eq(float("30")).unwrap());
+            assert!(rebuilt.sim.total_output.eq(float("15")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_reselects_across_raindexes_after_failure() {
+            let failing_raindex = Address::from([0x11u8; 20]);
+            let fallback_raindex = Address::from([0x22u8; 20]);
+            let mut failing = candidate("20", "1", 1);
+            failing.raindex = failing_raindex;
+            let mut fallback = candidate("20", "2", 2);
+            fallback.raindex = fallback_raindex;
+            let candidates = vec![failing, fallback];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "20");
+            let price_cap = float("10");
+            let (initial_raindex, initial) =
+                selection::select_best_raindex_simulation(candidates.clone(), mode, price_cap)
+                    .unwrap();
+            assert_eq!(initial_raindex, failing_raindex);
+
+            let mut remaining = candidates;
+            let (rebuilt_raindex, rebuilt) =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap)
+                    .unwrap()
+                    .unwrap();
+
+            assert_eq!(rebuilt_raindex, fallback_raindex);
+            assert_eq!(rebuilt.sim.legs.len(), 1);
+            assert!(rebuilt.sim.total_input.eq(float("20")).unwrap());
+            assert!(rebuilt.sim.total_output.eq(float("10")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_exact_spend_uses_healthy_leg_and_unused_fallback() {
+            let candidates = vec![
+                candidate("4", "1", 1),
+                candidate("4", "1.5", 2),
+                candidate("3", "2", 3),
+            ];
+            let mode = mode(TakeOrdersMode::SpendExact, "10");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+            assert_eq!(initial.legs.len(), 2);
+            assert!(initial.total_input.eq(float("10")).unwrap());
+
+            let mut remaining = candidates;
+            let (_, rebuilt) =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[1], mode, price_cap)
+                    .unwrap()
+                    .unwrap();
+
+            assert_eq!(rebuilt.sim.legs.len(), 2);
+            assert!(rebuilt.sim.total_input.eq(float("10")).unwrap());
+            assert!(rebuilt.sim.legs[0].candidate.ratio.eq(float("1")).unwrap());
+            assert!(rebuilt.sim.legs[1].candidate.ratio.eq(float("2")).unwrap());
+        }
+
+        #[test]
+        fn rebuild_skips_unidentifiable_raindex_and_selects_another() {
+            let failed_raindex = Address::from([0x11u8; 20]);
+            let fallback_raindex = Address::from([0x22u8; 20]);
+            let mut failed_a = candidate("5", "1", 1);
+            failed_a.raindex = failed_raindex;
+            let mut failed_b = candidate("5", "2", 2);
+            failed_b.raindex = failed_raindex;
+            let mut fallback = candidate("10", "3", 3);
+            fallback.raindex = fallback_raindex;
+            let mut remaining = vec![failed_a, failed_b, fallback];
+            let mode = mode(TakeOrdersMode::SpendUpTo, "10");
+            let price_cap = float("10");
+
+            let (selected, rebuilt) =
+                rebuild_without_raindex(&mut remaining, failed_raindex, mode, price_cap)
+                    .unwrap()
+                    .unwrap();
+
+            assert_eq!(selected, fallback_raindex);
+            assert_eq!(remaining.len(), 1);
+            assert!(remaining
+                .iter()
+                .all(|candidate| candidate.raindex == fallback_raindex));
+            assert_eq!(rebuilt.config.orders.len(), 1);
+        }
+
+        #[test]
+        fn rebuild_rejects_exact_mode_when_remaining_liquidity_is_insufficient() {
+            let candidates = vec![candidate("5", "1", 1), candidate("7.5", "2", 2)];
+            let mode = mode(TakeOrdersMode::SpendExact, "20");
+            let price_cap = float("10");
+            let initial = simulate_candidates(candidates.clone(), mode, price_cap).unwrap();
+
+            let mut remaining = candidates;
+            let result =
+                rebuild_without_failing_leg(&mut remaining, &initial.legs[0], mode, price_cap);
+
+            assert!(matches!(
+                result,
+                Err(RaindexError::InsufficientLiquidity {
+                    requested,
+                    available
+                }) if requested == "20" && available == "15"
+            ));
+        }
+    }
+
     #[cfg(target_family = "wasm")]
     mod wasm_tests {
         use crate::take_orders::TakeOrdersMode;

--- a/crates/common/src/raindex_client/take_orders/selection.rs
+++ b/crates/common/src/raindex_client/take_orders/selection.rs
@@ -1,9 +1,8 @@
 use crate::raindex_client::orders::RaindexOrder;
 use crate::raindex_client::RaindexError;
 use crate::take_orders::{
-    build_take_order_candidates_for_pair, simulate_buy_over_candidates,
-    simulate_spend_over_candidates, ParsedTakeOrdersMode, SignedContextInjector, SimulationResult,
-    TakeOrderCandidate,
+    build_take_order_candidates_for_pair, simulate_candidates, ParsedTakeOrdersMode,
+    SignedContextInjector, SimulationResult, TakeOrderCandidate,
 };
 use crate::utils::float::cmp_float;
 use crate::utils::timing::Timing;
@@ -76,6 +75,14 @@ pub(crate) fn worst_price(sim: &SimulationResult) -> Result<Option<Float>, Raind
     Ok(max)
 }
 
+fn selection_primary(sim: &SimulationResult, mode: ParsedTakeOrdersMode) -> Float {
+    if mode.is_exact_mode() && !mode.is_buy_mode() {
+        sim.total_input
+    } else {
+        sim.total_output
+    }
+}
+
 pub(crate) fn select_best_raindex_simulation(
     candidates: Vec<TakeOrderCandidate>,
     mode: ParsedTakeOrdersMode,
@@ -91,9 +98,6 @@ pub(crate) fn select_best_raindex_simulation(
             .push(candidate);
     }
 
-    let target = mode.target_amount();
-    let is_buy_mode = mode.is_buy_mode();
-
     let mut best_result: Option<(Address, SimulationResult)> = None;
     let raindex_count = raindex_candidates.len();
     let mut skipped_empty_sims = 0usize;
@@ -107,11 +111,7 @@ pub(crate) fn select_best_raindex_simulation(
     for (raindex_addr, candidates) in raindex_candidates {
         let candidate_count = candidates.len();
         info!(raindex = %raindex_addr, candidate_count, "simulating raindex candidates");
-        let sim = if is_buy_mode {
-            simulate_buy_over_candidates(candidates, target, price_cap)?
-        } else {
-            simulate_spend_over_candidates(candidates, target, price_cap)?
-        };
+        let sim = simulate_candidates(candidates, mode, price_cap)?;
 
         if sim.legs.is_empty() {
             skipped_empty_sims += 1;
@@ -119,39 +119,47 @@ pub(crate) fn select_best_raindex_simulation(
             continue;
         }
 
-        let achieved = sim.total_output;
+        let achieved = selection_primary(&sim, mode);
         debug!(
             raindex = %raindex_addr,
             legs_count = sim.legs.len(),
             total_input = %format_float(sim.total_input),
             total_output = %format_float(sim.total_output),
-            "raindex simulation achieved output"
+            "raindex simulation achieved target"
         );
 
         let is_better = match &best_result {
             None => true,
             Some((best_addr, best_sim)) => {
-                let best_achieved = best_sim.total_output;
+                let best_achieved = selection_primary(best_sim, mode);
 
                 if achieved.gt(best_achieved)? {
                     true
                 } else if achieved.eq(best_achieved)? {
-                    let sim_worst = worst_price(&sim)?;
-                    let best_worst = worst_price(best_sim)?;
-                    match (sim_worst, best_worst) {
-                        (Some(sw), Some(bw)) => match cmp_float(&sw, &bw)? {
-                            std::cmp::Ordering::Less => {
-                                debug!(raindex = %raindex_addr, best_raindex = %best_addr, "tie-break selected lower worst price");
-                                true
-                            }
-                            std::cmp::Ordering::Equal => {
-                                let wins = raindex_addr < *best_addr;
-                                debug!(raindex = %raindex_addr, best_raindex = %best_addr, selected = wins, "tie-break compared raindex address");
-                                wins
-                            }
-                            std::cmp::Ordering::Greater => false,
-                        },
-                        _ => raindex_addr < *best_addr,
+                    if sim.total_output.gt(best_sim.total_output)? {
+                        debug!(raindex = %raindex_addr, best_raindex = %best_addr, "tie-break selected higher output");
+                        true
+                    } else if sim.total_output.lt(best_sim.total_output)? {
+                        debug!(raindex = %raindex_addr, best_raindex = %best_addr, "tie-break rejected lower output");
+                        false
+                    } else {
+                        let sim_worst = worst_price(&sim)?;
+                        let best_worst = worst_price(best_sim)?;
+                        match (sim_worst, best_worst) {
+                            (Some(sw), Some(bw)) => match cmp_float(&sw, &bw)? {
+                                std::cmp::Ordering::Less => {
+                                    debug!(raindex = %raindex_addr, best_raindex = %best_addr, "tie-break selected lower worst price");
+                                    true
+                                }
+                                std::cmp::Ordering::Equal => {
+                                    let wins = raindex_addr < *best_addr;
+                                    debug!(raindex = %raindex_addr, best_raindex = %best_addr, selected = wins, "tie-break compared raindex address");
+                                    wins
+                                }
+                                std::cmp::Ordering::Greater => false,
+                            },
+                            _ => raindex_addr < *best_addr,
+                        }
                     }
                 } else {
                     false
@@ -215,6 +223,13 @@ mod tests {
         }
     }
 
+    fn spend_exact(amount: Float) -> ParsedTakeOrdersMode {
+        ParsedTakeOrdersMode {
+            mode: crate::take_orders::TakeOrdersMode::SpendExact,
+            amount,
+        }
+    }
+
     #[test]
     fn test_select_best_raindex_single_raindex() {
         let ob1 = Address::from([0x11u8; 20]);
@@ -259,6 +274,35 @@ mod tests {
         assert_eq!(winner, ob2);
         let expected_output = Float::parse("8".to_string()).unwrap();
         assert!(sim.total_output.eq(expected_output).unwrap());
+    }
+
+    #[test]
+    fn spend_exact_prefers_full_spend_over_larger_partial_output() {
+        let partial_raindex = Address::from([0x11u8; 20]);
+        let full_raindex = Address::from([0x22u8; 20]);
+        let partial = make_candidate(
+            partial_raindex,
+            Float::parse("100".to_string()).unwrap(),
+            Float::parse("0.05".to_string()).unwrap(),
+        );
+        let full = make_candidate(
+            full_raindex,
+            Float::parse("5".to_string()).unwrap(),
+            Float::parse("2".to_string()).unwrap(),
+        );
+
+        let (winner, sim) = select_best_raindex_simulation(
+            vec![partial, full],
+            spend_exact(Float::parse("10".to_string()).unwrap()),
+            high_price_cap(),
+        )
+        .unwrap();
+
+        assert_eq!(winner, full_raindex);
+        assert!(sim
+            .total_input
+            .eq(Float::parse("10".to_string()).unwrap())
+            .unwrap());
     }
 
     #[test]

--- a/crates/common/src/take_orders/mod.rs
+++ b/crates/common/src/take_orders/mod.rs
@@ -15,6 +15,6 @@ pub use preflight::{
 };
 pub use raindex_quote::injector::{NoopInjector, SignedContextInjector};
 pub use simulation::{
-    simulate_buy_over_candidates, simulate_spend_over_candidates, SelectedTakeOrderLeg,
-    SimulationResult,
+    simulate_buy_over_candidates, simulate_candidates, simulate_spend_over_candidates,
+    SelectedTakeOrderLeg, SimulationResult,
 };

--- a/crates/common/src/take_orders/preflight.rs
+++ b/crates/common/src/take_orders/preflight.rs
@@ -1,6 +1,6 @@
 use crate::utils::timing::Timing;
 use alloy::network::TransactionBuilder;
-use alloy::primitives::{Address, Bytes, U256};
+use alloy::primitives::{Address, Bytes, B256, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy::serde::WithOtherFields;
@@ -220,39 +220,57 @@ pub async fn find_failing_order_index(
     config: &TakeOrdersConfigV5,
     block_number: Option<u64>,
 ) -> Option<usize> {
+    match diagnose_take_orders_failure(provider, raindex, taker, config, block_number).await {
+        TakeOrdersFailureDiagnosis::FailingOrder(index) => Some(index),
+        TakeOrdersFailureDiagnosis::Recovered | TakeOrdersFailureDiagnosis::Unidentified => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TakeOrdersFailureDiagnosis {
+    FailingOrder(usize),
+    Recovered,
+    Unidentified,
+}
+
+pub(crate) async fn diagnose_take_orders_failure(
+    provider: &ReadProvider,
+    raindex: Address,
+    taker: Address,
+    config: &TakeOrdersConfigV5,
+    block_number: Option<u64>,
+) -> TakeOrdersFailureDiagnosis {
     let started_at = Timing::now();
     if config.orders.is_empty() {
         debug!(raindex = %raindex, "cannot find failing order in empty config");
-        return None;
+        return TakeOrdersFailureDiagnosis::Unidentified;
     }
 
     if config.orders.len() == 1 {
-        let result = simulate_take_orders(provider, raindex, taker, config, block_number).await;
-        if result.is_err() {
+        let first_retry =
+            simulate_take_orders(provider, raindex, taker, config, block_number).await;
+        if first_retry.is_err()
+            && simulate_take_orders(provider, raindex, taker, config, block_number)
+                .await
+                .is_err()
+        {
             warn!(
                 raindex = %raindex,
                 taker = %taker,
                 block_number = ?block_number,
                 failing_order_index = 0usize,
-                simulations_run = 1usize,
+                simulations_run = 2usize,
                 duration_ms = started_at.elapsed_ms(),
                 "identified failing order"
             );
-            return Some(0);
+            return TakeOrdersFailureDiagnosis::FailingOrder(0);
         }
-        return None;
+        return TakeOrdersFailureDiagnosis::Recovered;
     }
 
     let mut simulations_run = 0usize;
     for idx in 0..config.orders.len() {
-        let single_order_config = TakeOrdersConfigV5 {
-            minimumIO: config.minimumIO,
-            maximumIO: config.maximumIO,
-            maximumIORatio: config.maximumIORatio,
-            IOIsInput: config.IOIsInput,
-            orders: vec![config.orders[idx].clone()],
-            data: config.data.clone(),
-        };
+        let single_order_config = single_order_probe_config(config, idx);
 
         let result =
             simulate_take_orders(provider, raindex, taker, &single_order_config, block_number)
@@ -260,17 +278,38 @@ pub async fn find_failing_order_index(
         simulations_run += 1;
 
         if result.is_err() {
-            warn!(
-                raindex = %raindex,
-                taker = %taker,
-                block_number = ?block_number,
-                failing_order_index = idx,
-                simulations_run,
-                duration_ms = started_at.elapsed_ms(),
-                "identified failing order"
-            );
-            return Some(idx);
+            let retry =
+                simulate_take_orders(provider, raindex, taker, &single_order_config, block_number)
+                    .await;
+            simulations_run += 1;
+            if retry.is_err() {
+                warn!(
+                    raindex = %raindex,
+                    taker = %taker,
+                    block_number = ?block_number,
+                    failing_order_index = idx,
+                    simulations_run,
+                    duration_ms = started_at.elapsed_ms(),
+                    "identified failing order"
+                );
+                return TakeOrdersFailureDiagnosis::FailingOrder(idx);
+            }
         }
+    }
+
+    if simulate_take_orders(provider, raindex, taker, config, block_number)
+        .await
+        .is_ok()
+    {
+        info!(
+            raindex = %raindex,
+            taker = %taker,
+            block_number = ?block_number,
+            simulations_run,
+            duration_ms = started_at.elapsed_ms(),
+            "take-orders preflight recovered during failure diagnosis"
+        );
+        return TakeOrdersFailureDiagnosis::Recovered;
     }
 
     warn!(
@@ -281,12 +320,27 @@ pub async fn find_failing_order_index(
         duration_ms = started_at.elapsed_ms(),
         "could not identify failing order"
     );
-    None
+    TakeOrdersFailureDiagnosis::Unidentified
+}
+
+fn single_order_probe_config(config: &TakeOrdersConfigV5, idx: usize) -> TakeOrdersConfigV5 {
+    TakeOrdersConfigV5 {
+        // `minimumIO` is an aggregate constraint. Keeping the batch minimum
+        // when probing one leg would make healthy partial legs fail in exact
+        // modes and incorrectly identify them as the cause of the revert.
+        minimumIO: B256::ZERO,
+        maximumIO: config.maximumIO,
+        maximumIORatio: config.maximumIORatio,
+        IOIsInput: config.IOIsInput,
+        orders: vec![config.orders[idx].clone()],
+        data: config.data.clone(),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use raindex_bindings::IRaindexV6::TakeOrderConfigV4;
 
     #[test]
     fn test_preflight_error_display() {
@@ -347,6 +401,28 @@ mod tests {
         let decoded = decoded.unwrap();
         assert_eq!(decoded.spender, spender);
         assert_eq!(decoded.amount, amount);
+    }
+
+    #[test]
+    fn single_order_probe_drops_aggregate_minimum_io() {
+        let order = TakeOrderConfigV4::default();
+        let config = TakeOrdersConfigV5 {
+            minimumIO: U256::from(10).into(),
+            maximumIO: U256::from(20).into(),
+            maximumIORatio: U256::from(2).into(),
+            IOIsInput: true,
+            orders: vec![order.clone(), TakeOrderConfigV4::default()],
+            data: Bytes::from(vec![1]),
+        };
+
+        let probe = single_order_probe_config(&config, 0);
+
+        assert_eq!(probe.minimumIO, B256::ZERO);
+        assert_eq!(probe.maximumIO, config.maximumIO);
+        assert_eq!(probe.maximumIORatio, config.maximumIORatio);
+        assert_eq!(probe.IOIsInput, config.IOIsInput);
+        assert_eq!(probe.orders, vec![order]);
+        assert_eq!(probe.data, config.data);
     }
 }
 

--- a/crates/common/src/take_orders/simulation.rs
+++ b/crates/common/src/take_orders/simulation.rs
@@ -1,4 +1,5 @@
 use super::candidates::TakeOrderCandidate;
+use super::config::ParsedTakeOrdersMode;
 use crate::raindex_client::RaindexError;
 use crate::utils::float::cmp_float;
 use crate::utils::timing::Timing;
@@ -34,6 +35,18 @@ pub struct SimulationResult {
     pub legs: Vec<SelectedTakeOrderLeg>,
     pub total_input: Float,
     pub total_output: Float,
+}
+
+pub fn simulate_candidates(
+    candidates: Vec<TakeOrderCandidate>,
+    mode: ParsedTakeOrdersMode,
+    price_cap: Float,
+) -> Result<SimulationResult, RaindexError> {
+    if mode.is_buy_mode() {
+        simulate_buy_over_candidates(candidates, mode.target_amount(), price_cap)
+    } else {
+        simulate_spend_over_candidates(candidates, mode.target_amount(), price_cap)
+    }
 }
 
 fn sort_candidates_by_price(candidates: &mut [TakeOrderCandidate]) -> Result<(), RaindexError> {


### PR DESCRIPTION
## Dependent PRs

- Rainix CI prerequisite (merge first): https://github.com/rainlanguage/rainix/pull/295
- REST integration (merge after this): https://github.com/ST0x-Technology/st0x.rest.api/pull/171

## Motivation

Take-order preflight could identify a reverting leg and remove it from the encoded config while retaining the original simulation totals. The returned calldata could therefore report `expectedSell` and `expectedBuy` for liquidity that was no longer executable. The old retry path also could not activate an unused fallback candidate or move to another Raindex.

In the production incident at block 49,797,519, the initial two-leg simulation nearly filled a `0.05` spend. After one leg failed preflight, only `0.04310434222334697689407343024988324343123847171843280166595003948319` remained executable, but the response still reported the stale near-`0.05` total.

## Solution

- Remove the exact failed candidate, including Raindex, order, IO indices, signed context, maximum output, and ratio.
- Re-simulate the remaining global candidate pool and rebuild calldata, selected legs, and aggregate totals together.
- Re-run Raindex selection after each removal so unused candidates and cross-Raindex fallbacks can be selected.
- Re-check token approval whenever reselection changes the Raindex spender.
- Distinguish recovered transient simulations from deterministic order failures.
- Probe individual orders without the aggregate `minimumIO`, preventing healthy partial legs from being blamed in exact modes.
- Skip a Raindex when an aggregate-only failure cannot be attributed to a single order.
- Rank `SpendExact` simulations by fulfilled input, then output, before price and address tie-breaks.
- Keep exact modes strict when remaining liquidity cannot meet the contract minimum.

## Regression coverage

The incident regression reconstructs the logged two-leg values and verifies that removing the reverting leg rebuilds the result with the surviving executable input instead of the stale initial total. Additional tests cover partial spend and buy totals, unused fallbacks, duplicate executable orders, signed-context identity, cross-Raindex reselection, aggregate Raindex fallback, exact-mode insufficiency, and `SpendExact` ranking.

## Checks

- `nix develop -c cargo test -p raindex_common` — 1,169 passed
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo check -p raindex_common --target wasm32-unknown-unknown`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved order selection to prioritize the best available liquidity and pricing, including exact-spend scenarios.
  * Added more reliable fallback behavior when individual orders or trading venues fail.
  * The system can now reselect alternatives across available Raindexes and recalculate totals automatically.
  * Enhanced handling of unidentified and recovered failures during order preparation.
  * Improved approval checks and execution tracking during repeated selection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->