### PR TITLE
Remove submodule-era residue; repair the copilot build fallback

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,9 +82,13 @@ nix develop -c cargo test --workspace
 
 ## Fallback if the end-of-session gate fails early
 
-If the gate dies before it reaches the tests, the dependency tree is not in
-place. Rebuild it from scratch, one workspace at a time, so you can see which
-step breaks:
+Use this when a step fails because the dependency tree is not in place, rather
+than because your change is wrong. That is not only the two bootstrap lines:
+`lint-format-check:all` runs `@rainlanguage/raindex`'s `check`, which is `tsc`
+over `dist/`, and `build:ui` builds `@rainlanguage/ui-components` against that
+same `dist/`, so on a tree that has never been built both die on missing files
+rather than on anything you wrote. Rebuild from scratch, one workspace at a
+time, so you can see which step breaks:
 
 ```bash
 nix develop -c forge soldeer install
@@ -98,6 +102,10 @@ nix develop .#wasm-shell -c bash -c '
   npm run build -w @rainlanguage/webapp
 '
 ```
+
+A failure that names your own code — a lint rule, a type error in a file you
+touched, a failing assertion — is a real failure, and reinstalling will not
+change it. Debug it where it is reported.
 
 Solidity dependencies are Soldeer packages, resolved into `dependencies/` by
 `forge soldeer install` (`foundry.toml` sets `libs = ['dependencies']`). They

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,9 @@ Partial commits are OK during the session. Before your final commit of the
 session, fully mirror CI:
 
 ```bash
-./prep-all.sh
+# Bootstrap — if either of these fails, jump to the fallback below.
+nix develop -c forge soldeer install
+nix develop -c forge build
 nix develop -c npm run lint-format-check:all
 nix develop -c npm run build:raindex   # if Rust/raindex changed
 nix develop -c npm run build:ui
@@ -78,22 +80,39 @@ nix develop -c npm run test
 nix develop -c cargo test --workspace
 ```
 
-## Fallback if end-of-session `./prep-all.sh` fails early
+## Fallback if the end-of-session gate fails early
 
-If the end-of-session gate fails during `./prep-all.sh`, run these steps
-sequentially so dependencies still build:
+If the gate dies before it reaches the tests, the dependency tree is not in
+place. Rebuild it from scratch, one workspace at a time, so you can see which
+step breaks:
 
 ```bash
-nix develop -c forge install
-nix develop -c bash -c '(cd lib/rain.interpreter && rainix-sol-prelude && rainix-rs-prelude && rainlang-prelude)'
-nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.interpreter.interface/lib/rain.math.float && rainix-sol-prelude && rainix-rs-prelude)'
-nix develop -c bash -c '(cd lib/rain.interpreter/lib/rain.metadata && rainix-sol-prelude && rainix-rs-prelude)'
-nix develop -c rainix-sol-prelude && nix develop -c rainix-rs-prelude && nix develop -c raindex-prelude
+nix develop -c forge soldeer install
+nix develop -c forge build
 nix develop -c raindex-ui-components-prelude
-nix develop -c npm run build -w @rainlanguage/raindex
-nix develop -c npm run build -w @rainlanguage/ui-components
-nix develop -c npm run build -w @rainlanguage/webapp
+nix develop .#wasm-shell -c bash -c '
+  set -euxo pipefail
+  npm install --no-check
+  npm run build -w @rainlanguage/raindex
+  npm run build -w @rainlanguage/ui-components
+  npm run build -w @rainlanguage/webapp
+'
 ```
+
+Solidity dependencies are Soldeer packages, resolved into `dependencies/` by
+`forge soldeer install` (`foundry.toml` sets `libs = ['dependencies']`). They
+are plain source drops — there is nothing to prepare or build inside one, so
+there is no per-dependency step here.
+
+`npm install --no-check` must run from the workspace root, and `.#wasm-shell` is
+a slim shell whose `shellHook` does not run it for you — hence the explicit
+first line inside the `bash -c`. `forge` and `raindex-ui-components-prelude`
+come from the default `nix develop -c` shell; `.#wasm-shell` has neither.
+
+If the problem is stale committed artifacts (`meta/`, `src/generated/`,
+`crates/*/abis`, `subgraph/`) rather than a build that will not run, that is the
+`copy-artifacts` regen cascade and not this bootstrap — follow the runbook in
+the root `CLAUDE.md`.
 
 Goal: all CI checks in `.github/workflows` pass. Be patient with long
 builds/tests and never commit with failing lint/tests.

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,6 +1,6 @@
 # Publish only the Solidity source (src/) to Soldeer. raindex is a large
 # multi-language repo; without this the push zips the whole tree (crates/,
-# packages/, subgraph/, lib/, target/, node_modules/, audit/ ...) and fails.
+# packages/, subgraph/, target/, node_modules/, audit/ ...) and fails.
 # Same syntax as .gitignore.
 
 # Tooling / repo files
@@ -15,7 +15,6 @@
 .git
 .github
 .gitignore
-.gitmodules
 .pre-commit-config.yaml
 .prettierignore
 .soldeerignore
@@ -39,7 +38,6 @@ slither.config.json
 /flake.lock
 /flake.nix
 /foundry.toml
-/lib
 /meta
 /node_modules
 /out

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -19,7 +19,6 @@ path = [
   "remappings.txt",
   "soldeer.lock",
   "slither.config.json",
-  "typeshare.toml",
   "REUSE.toml",
   "package.json",
   "package-lock.json",


### PR DESCRIPTION
Closes https://github.com/rainlanguage/raindex/issues/2834

## What was dangling

`git ls-files --stage | grep ^160000` is empty and there is no `.gitmodules` and
no `lib/` in the tree, so every reference below points at nothing.

- `.soldeerignore` line 18 `.gitmodules`, line 42 `/lib`, plus `lib/` in the
  header comment on line 3.
- `REUSE.toml` line 22 `"typeshare.toml"` — no such file, and `.gitignore` does
  not list one either, so the annotation matched nothing in any state.
- `.github/copilot-instructions.md` lines 87–90 — the submodule-era build
  fallback.

## `.soldeerignore` — only the submodule entries

`.soldeerignore` is a publish **filter**, not a description of the tree. An
entry naming a path that is absent from a clean checkout is still a live rule
at `soldeer push` time, when `/out`, `/cache`, `/dependencies`, `/target`,
`/node_modules`, `.env` and `.pre-commit-config.yaml` all exist. Removing one
publishes that path into the package the next time it appears.

So only `.gitmodules` and `/lib` are removed — the two entries whose subject can
never come back (rainix CI's
[`no-submodules`](https://github.com/rainlanguage/rainix/blob/main/.github/actions/no-submodules/action.yml)
check fails on a root `.gitmodules` or any committed gitlink, and `foundry.toml`
sets `libs = ['dependencies']` so forge never creates `lib/`). Every other entry
is left exactly as it is. `REUSE.toml` is the opposite case — its annotations
describe files that exist — so the dangling `typeshare.toml` entry goes.

## The copilot-instructions fallback

This is the part worth reading. It fires when someone's build is already broken,
so it was replaced rather than deleted.

**Everything in the old recipe was dead**, not just the paths the issue names:

| old line                                     | why it fails                                                                  |
| -------------------------------------------- | ----------------------------------------------------------------------------- |
| `forge install`                               | the submodule command; soldeer's is `forge soldeer install`                    |
| `cd lib/rain.interpreter/…` (3 lines)         | nested submodule paths that do not exist; `rain.interpreter` is not a dependency of this repo any more (`soldeer.lock` carries `rain-interpreter-interface` 0.1.0) |
| `rainix-sol-prelude`, `rainix-rs-prelude`, `rainlang-prelude` | do not exist. `nix eval .#packages.x86_64-linux --apply builtins.attrNames` on this repo returns `build-js-bindings js-install prettier-bundle rain-cli raindex-cli-artifact raindex-prelude raindex-rs-test raindex-ui-components-prelude rainix-rs-static rainix-sol-artifacts rainix-wasm-artifacts rainix-wasm-browser-test rainix-wasm-test rust-shell-test sol-shell-test test-js-bindings` — no prelude among them, at the `flake.lock` pin (rainix `f22d4dca`) or on rainix `main` |

**And its trigger was dead too.** The section was titled "Fallback if
end-of-session `./prep-all.sh` fails early", and §3's end-of-session gate ran
`./prep-all.sh` as its first line. That script was deleted in `f3dcc8cf6`
("Remove prep-all.sh + pointers.sh; consolidate CI on cachix"), so the gate died
on line 1 with `No such file or directory` and the fallback could never be
reached as written. Fixing the recipe without fixing what invokes it would have
left the hole open, so §3's `./prep-all.sh` is replaced in the same change. That
is the one edit here beyond the issue's literal list.

**What replaced it** is the bootstrap CI actually runs, not a guess:

- `forge soldeer install` then `forge build` — `rainix-sol-static.yaml`,
  `rainix-sol-test.yaml`, `rainix-sol-legal.yaml` and
  `rainix-copy-artifacts.yaml` all open with exactly this pair, and it is the
  documented bootstrap in this repo's own `README.md` and `AGENTS.md`.
- `raindex-ui-components-prelude` — defined in this repo's `flake.nix` and in
  the default devshell; it is in the README bootstrap and in
  `copilot-setup-steps.yml`.
- The `.#wasm-shell` block is copied verbatim from `test-webapp.yaml` /
  `test-ui-components.yaml`, including the workspace-root
  `npm install --no-check` that `AGENTS.md` requires and that the slim shell's
  `shellHook` does not do for you.

Three short paragraphs replace the per-dependency `cd` steps and say why there
are none any more (soldeer packages are plain source drops under
`dependencies/`), which shell provides what, and that stale committed artifacts
are the `copy-artifacts` regen cascade in the root `CLAUDE.md`, not this
bootstrap.

## Verification

- `git ls-files --stage | grep ^160000` → empty, before touching `.gitmodules`.
- No `.gitmodules` reference anywhere in the tree; no `lib/` reference outside
  `package-lock.json` bin paths and one unrelated Rust "lib/bin targets" phrase;
  no `typeshare` reference outside the gitignored, generated
  `packages/ui-components/src/lib/typeshare`.
- `pre-commit run --all-files` in rainix `rust-shell` (the `rs-static` gate,
  which is what formats markdown via `denofmt`) — all 11 hooks pass.
- `reuse lint` in rainix `sol-shell` (the `rainix-sol / legal` gate) with the
  `typeshare.toml` annotation removed — 1238/1238 files compliant.
- **The new recipe was run, not just derived.** On a fresh clone of this branch,
  `nix develop -c bash -c 'forge soldeer install && reuse lint && forge build'`
  exits 0 — `dependencies/` gets all 17 soldeer packages and `forge build`
  succeeds (its output is pre-existing `forge-lint` warnings only).
  `nix develop -c raindex-ui-components-prelude` was run separately because no
  PR CI job covers it. The `.#wasm-shell` npm block is exercised verbatim by
  this PR's own `test-webapp` / `test-ui-components` jobs.

## Noted, not fixed

Two workflow comments still contain the string `forge install`, both explaining
why it is *not* done there rather than instructing anyone to run it:
`.github/workflows/npm-package-release.yml:113` and
`.github/workflows/vercel-docs-preview.yaml:56`. The latter also references the
deleted `./prep-all.sh`. #2834 declares `.github/workflows/` clean and out of
scope, so they are left alone.

## QA

- Discriminating tests: n/a — the diff is one prose file plus two
  non-executable config manifests (`.soldeerignore`, `REUSE.toml`). No code
  path changes, so there is no behaviour a unit test could pin. The executable
  checks that do cover these files were run instead:
  `pre-commit run --all-files` in rainix `rust-shell` (all 11 hooks pass — this
  is the `rs-static` gate and it is what formats markdown, via `denofmt`) and
  `reuse lint` in rainix `sol-shell` (the `rainix-sol / legal` gate — 1238/1238
  files compliant with `typeshare.toml` removed).
- Mutations applied: n/a — nothing executable in the diff to mutate. The
  equivalent falsification was run against the prose instead: every command in
  the old recipe was checked for existence rather than assumed dead.
  `nix eval .#packages.x86_64-linux --apply builtins.attrNames` on this repo
  shows no `rainix-sol-prelude`, `rainix-rs-prelude` or `rainlang-prelude`, at
  the `flake.lock` rainix pin (`f22d4dca`) and on rainix `main`;
  `git log --all -- prep-all.sh` shows the script deleted in `f3dcc8cf6`;
  `git ls-files --stage | grep ^160000` is empty and there is no `.gitmodules`
  or `lib/`. Each replacement command was checked the same way rather than
  written from memory (see the table and source list above).
- Oracle: the CI workflows, independent of the doc being edited —
  `rainix-sol-static.yaml`, `rainix-sol-test.yaml`, `rainix-sol-legal.yaml`,
  `rainix-copy-artifacts.yaml` for the Solidity half; `test-webapp.yaml`,
  `test-ui-components.yaml`, `copilot-setup-steps.yml` for the JS half; and
  this repo's `README.md` / `AGENTS.md` bootstrap. The new recipe is what those
  run, not a reconstruction.
- Category check: #2834 asks for four things — `.soldeerignore` 18 and 42,
  `REUSE.toml` 22, the `copilot-instructions.md` fallback rewritten against the
  soldeer layout, and no `.gitmodules` / `lib/` / `forge install` reference left
  outside `dependencies/`. All four covered. The `lib/` in `.soldeerignore`'s
  header comment (line 3) is covered as part of the fourth. Only lines 18 and
  42 are removed from `.soldeerignore` — see the scoping note above. §3's
  `./prep-all.sh` is one line beyond the issue's list, taken because the
  fallback's own trigger is otherwise dead; called out explicitly above rather
  than folded in silently. The two workflow comments that mention
  `forge install` are listed under "Noted, not fixed" — #2834 declares
  `.github/workflows/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the end-of-session build process to install Solidity dependencies and build required packages in sequence.
  * Improved fallback build behavior for the workspace and WASM shell.
  * Updated dependency publishing and licensing configuration to reflect the current project layout.
  * Added guidance for handling Solidity dependencies and artifact regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
