### PR TITLE
Float the suites declaration's pragma, as every other abstract here does

### DIFF
--- a/src/abstract/RaindexDeploySuites.sol
+++ b/src/abstract/RaindexDeploySuites.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-DCL-1.0
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
-pragma solidity =0.8.25;
+pragma solidity ^0.8.25;
 
 import {DeployCandidate, DeploySuite, RainDeploySuitesBase} from "./RainDeploySuitesBase.sol";
 import {RaindexV6} from "../concrete/raindex/RaindexV6.sol";


### PR DESCRIPTION
`src/abstract/RaindexDeploySuites.sol` was the only abstract in this repo pinned with `=0.8.25`; the other five float `^0.8.19`, and all four of the org's conforming deploy repos float `^0.8.25` on the same file.

It is published: `.soldeerignore` drops `script/` and `test/` but ships `src/`, so a consumer that inherits this declaration inherits the pin with it — an exact pin on a shipped abstract forces every downstream repo onto 0.8.25 exactly.

The org convention (documented in the standard derived from rain.deploy and its four conforming consumers): concretes, scripts and tests pin `=0.8.25`; libraries, abstracts and generated files float `^0.8.25` so downstream consumers on another 0.8.x still compile.

Written as part of the deploy-standard conformance work on #2841; it missed that PR's merge by a few minutes, hence this follow-up. No other conformance work is outstanding from that audit — the rest landed in `93377dee1`.

## QA

- Discriminating tests: n/a — a pragma directive has no runtime behaviour to test. The compiler is the check: the repo builds under `solc 0.8.25` before and after, and `forge fmt --check` and `rainix-sol/static` pass on the change.
- Mutations applied: n/a — no logic in the diff; the only possible mutation is a different pragma, which either compiles identically or fails the build outright.
- Oracle: the convention as observed in the other five abstracts in this repo and in the same file across rain.math.float.deploy, rain.extrospection.deploy, rain.factory.deploy and rain.metadata.deploy — all four float it. Independent of anything in this diff.
- Category check: no linked issue; the work order was deploy-standard conformance. This covers the one axis that missed #2841's merge. Deferred elsewhere with reasons on #2841: currency-workflow naming, committed `remappings.txt`, `test/abstract/` layout, the 36 files importing `rain-deploy-0.1.2/…` via the foundry.toml alias, and the missing `<Thing>DeploySuitesTest`.
