### PR TITLE
Expose the deploy reusable's verify input

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -37,6 +37,13 @@ on:
         required: false
         type: boolean
         default: false
+
+      verify:
+        description: >-
+          Verify on the block explorer after broadcasting. Turn it off when the verification retry loop would outlast the deploy; `Manual sol verify` repairs verification later without re-broadcasting.
+        required: false
+        type: boolean
+        default: true
 jobs:
   deploy:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
@@ -45,4 +52,5 @@ jobs:
       script: ${{ inputs.script }}
       network: ${{ inputs.network }}
       legacy: ${{ inputs.legacy }}
+      verify: ${{ inputs.verify }}
     secrets: inherit

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -37,7 +37,6 @@ on:
         required: false
         type: boolean
         default: false
-
       verify:
         description: >-
           Verify on the block explorer after broadcasting. Turn it off when the verification retry loop would outlast the deploy; `Manual sol verify` repairs verification later without re-broadcasting.


### PR DESCRIPTION
`rainix-manual-sol-artifacts.yaml` takes a `verify` input (default `true`), but this repo's caller never passed it, so a dispatch had no way to turn verification off.

That became load-bearing today. Six deploy dispatches went out for the ethereum and hyperevm gap; four broadcast and failed at hyperevm on funds within ~15 minutes each, while two sat in the forge step for over 100 minutes without reaching their ethereum broadcast — with no pending transaction on ethereum (`latest` and `pending` nonce both 25), so nothing was stuck in the mempool. The reusable runs `--verify --retries 40 --delay 15`, which is up to 10 minutes of retries per contract per network before it gives up.

With this input, the same dispatch can broadcast without verification and `Manual sol verify` repairs verification afterwards, which is what that workflow exists for — it never reads `DEPLOYMENT_KEY`, so it cannot re-broadcast.

## QA

- Discriminating tests: n/a — a workflow input passthrough has no test harness in this repo, and CI does not execute `workflow_dispatch` paths. The check that matters is that the dispatch form renders the new input and that a run with `verify: false` reaches broadcast; both are observable only on dispatch, which is a deliberate human action.
- Mutations applied: n/a — no logic in the diff. The single wiring line either passes the input or the workflow fails to parse.
- Oracle: `rainix-manual-sol-artifacts.yaml`'s own input list, which declares `verify` with `default: true`; the default here matches so existing dispatches keep their current behaviour.
- Category check: no linked issue. Covers the missing passthrough only. It does not change any default, does not touch the deploy script, and does not affect the runs already in flight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether deployed contracts are verified on a block explorer after broadcasting.
  * Verification is enabled by default and can be adjusted when manually running the deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->