### PR TITLE
Add the Manual sol verify caller workflow

### DIFF
--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -19,8 +19,9 @@ name: Manual sol verify
 # cannot: its `artifactPath` is the bare name `RouteProcessor4`, and this repo
 # holds no Solidity source for it — only the pinned
 # `ROUTE_PROCESSOR_4_CREATION_CODE` bytes taken from sushiswap — so `forge
-# build` emits no artifact under that name and there is nothing here to submit.
-# Dispatching it fails on the first explorer rather than verifying anything.
+# build` emits no artifact under that name and `forge verify-contract` has
+# nothing to submit. Recorded here so the next person does not spend a run
+# finding out.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -1,0 +1,66 @@
+name: Manual sol verify
+# Explorer source verification for a suite that is ALREADY on chain, run by
+# hand.
+#
+# `manual-sol-artifacts.yaml` submits source only for what its own run
+# broadcast, and the broadcast is idempotent: a rerun against networks that
+# already hold the code broadcasts nothing, so there is nothing for `--verify`
+# to submit and the run is green having verified nothing. A deploy that landed
+# and then went unverified — a bad explorer key, a rate limit, an explorer that
+# was down, or `verify: false` because the retry loop would have outlasted the
+# deploy — is repaired here rather than by re-dispatching the deploy.
+#
+# Deliberately `workflow_dispatch` only, like the deploy. Unlike the deploy this
+# never broadcasts and never reads `DEPLOYMENT_KEY`: `forge verify-contract`
+# talks to the explorer API and nothing else, so it is safe to re-run and is
+# already a no-op ("already verified") against an explorer that has the source.
+#
+# Five of this repo's six suites can be dispatched here. `route-processor`
+# cannot: its `artifactPath` is the bare name `RouteProcessor4`, and this repo
+# holds no Solidity source for it — only the pinned
+# `ROUTE_PROCESSOR_4_CREATION_CODE` bytes taken from sushiswap — so `forge
+# build` emits no artifact under that name and there is nothing here to submit.
+# Dispatching it fails on the first explorer rather than verifying anything.
+on:
+  workflow_dispatch:
+    inputs:
+      contract:
+        type: string
+        required: true
+        description: |
+          Artifact path of the contract to submit, `path:Contract`. Paired with
+          `address` on the `manual verification command:` line
+          `script/Deploy.sol` prints for every network, whether it deployed
+          there or skipped it, so a run of the deploy is where both values come
+          from. They are also the `artifactPath` and the generated
+          `DEPLOYED_ADDRESS` of the suites in
+          `src/abstract/RaindexDeploySuites.sol`.
+      address:
+        type: string
+        required: true
+        description: |
+          The deployed address. One value for every network, because the Zoltu
+          factory derives one address from the creation code.
+      networks:
+        type: string
+        required: true
+        default: arbitrum base base-sepolia mainnet flare hyperliquid polygon
+        description: |
+          Which explorers to submit to. FOUNDRY's chain names, not the
+          `[rpc_endpoints]` aliases, and the two differ on three of the seven:
+          the aliases `base_sepolia`, `ethereum` and `hyperevm` are rejected
+          outright, and the chain names are `base-sepolia`, `mainnet` and
+          `hyperliquid`. The `manual verification command:` line is NOT a source
+          for this field — it prints `--chain` with the alias it broadcast
+          under, which is the spelling that gets rejected here. The default is
+          `LibRainDeploy.supportedNetworks()` spelled the working way, i.e.
+          every network `script/Deploy.sol` broadcasts to, so it has to move
+          when that does.
+jobs:
+  verify:
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main
+    with:
+      contract: ${{ inputs.contract }}
+      address: ${{ inputs.address }}
+      networks: ${{ inputs.networks }}
+    secrets: inherit


### PR DESCRIPTION
## Why

Every one of the six `sol-v0.1.15` deploys ran with `verify: false` — the verification retry loop was hanging the runs — so all six contracts are live on all seven networks with no source on any explorer:

| run | suite | contract | address |
| --- | --- | --- | --- |
| [32741510029](https://github.com/rainlanguage/raindex/actions/runs/32741510029) | `raindex` | `src/concrete/raindex/RaindexV6.sol:RaindexV6` | `0x37FC0EFec37D19f8A221aa4F8F7600C9ba2AcD20` |
| [32741998081](https://github.com/rainlanguage/raindex/actions/runs/32741998081) | `subparser` | `src/concrete/parser/RaindexV6SubParser.sol:RaindexV6SubParser` | `0x09Bc7AF266012F44fb41D8Bd682da931666605e1` |
| [32742593985](https://github.com/rainlanguage/raindex/actions/runs/32742593985) | `route-processor` | `RouteProcessor4` | `0x6E2d0e71d900474b262E545Bc4C98b71ab368d21` |
| [32743189873](https://github.com/rainlanguage/raindex/actions/runs/32743189873) | `arb-generic-pool-order-taker` | `src/concrete/arb/GenericPoolRaindexV6ArbOrderTaker.sol:GenericPoolRaindexV6ArbOrderTaker` | `0xE84c106B0A89A164d2D65205B9EBAE37c15Fd84a` |
| [32743780903](https://github.com/rainlanguage/raindex/actions/runs/32743780903) | `arb-route-processor-order-taker` | `src/concrete/arb/RouteProcessorRaindexV6ArbOrderTaker.sol:RouteProcessorRaindexV6ArbOrderTaker` | `0x1350420cbf3E9eb8F1734bbe466e0F303579eE24` |
| [32744257333](https://github.com/rainlanguage/raindex/actions/runs/32744257333) | `arb-generic-pool-flash-borrower` | `src/concrete/arb/GenericPoolRaindexV6FlashBorrower.sol:GenericPoolRaindexV6FlashBorrower` | `0x032d9D94A79909F3b337ECFE6f73f4e86bA79c7E` |

Each address is the `DEPLOYED_ADDRESS` in the matching `src/generated/0_1_15/` snapshot; each artifact path is the matching `artifactPath` in `src/abstract/RaindexDeploySuites.sol`.

Re-dispatching `Manual sol artifacts` cannot repair this. The deploy is deterministic and therefore idempotent: a rerun against networks that already hold the code broadcasts nothing, `--verify` gets nothing to submit, and the run goes green having verified nothing. `manual-sol-artifacts.yaml`'s own `verify` input description already names `Manual sol verify` as the repair path — this PR is that workflow, which the repo did not have.

## What

One file. A thin `workflow_dispatch` caller over `rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main`, the same shape as the one in `rainlanguage/rain.deploy`. It never broadcasts and never reads `DEPLOYMENT_KEY` — `forge verify-contract` talks to the explorer API and nothing else — so it is safe to re-run and is a no-op against an explorer that already holds the source.

### The `networks` default is FOUNDRY chain names, not the RPC aliases

`forge verify-contract --chain` takes foundry's own chain names. Three of this repo's seven `[rpc_endpoints]` aliases are spelled differently and are rejected outright:

| `[rpc_endpoints]` alias | `--chain` name |
| --- | --- |
| `base_sepolia` | `base-sepolia` |
| `ethereum` | `mainnet` |
| `hyperevm` | `hyperliquid` |

The other four (`arbitrum`, `base`, `flare`, `polygon`) are spelled the same in both.

This is a live trap, not a theoretical one: the `manual verification command:` line `LibRainDeploy` prints after each broadcast emits `--chain` with the **alias** it broadcast under — e.g. `forge verify-contract --chain hyperevm 0x37FC0EFec37D19f8A221aa4F8F7600C9ba2AcD20 src/concrete/raindex/RaindexV6.sol:RaindexV6`. Copying that line's `--chain` value into this input is the exact mistake that gets rejected, so the input description says not to.

### `route-processor` is not dispatchable, and the header says so

Five of the six suites can be submitted here. `route-processor` cannot. Its `artifactPath` is the bare name `RouteProcessor4`, and this repo carries no Solidity source for it — only the pinned `ROUTE_PROCESSOR_4_CREATION_CODE` bytes lifted from sushiswap in `src/lib/deploy/LibRouteProcessor4CreationCode.sol` — so `forge build` emits no artifact under that name and `forge verify-contract` has nothing to submit. That is recorded in the workflow header so the next person does not spend a run finding out.

So this PR makes five of this repo's six deployed contracts verifiable, not six. Getting source onto the explorers for the Zoltu-deployed `RouteProcessor4` is a separate problem and is not solved here.

## Dispatching it

After merge, once per contract:

```
gh workflow run "Manual sol verify" --repo rainlanguage/raindex \
  -f contract=src/concrete/raindex/RaindexV6.sol:RaindexV6 \
  -f address=0x37FC0EFec37D19f8A221aa4F8F7600C9ba2AcD20
```

`networks` defaults to all seven, so it is only passed to narrow a run.

Not merged by me. It deploys nothing, but it is the thing that gets pointed at seven explorers, so it wants a human on the button.

## QA

- Discriminating tests: n/a, with the reason. The diff is one declarative GitHub workflow file with no executable logic of its own, and this repo has no harness that executes workflow YAML (no actionlint, no yamlfmt, no workflow lint job in CI) — a test added here would assert the file's own text back at itself. What was checked instead is below, and all of it is against sources outside the file.
- Mutations applied: n/a, with the reason. There are no code lines to mutate; GitHub is the consumer, and the substantive guard already lives upstream in `rainix-manual-sol-verify.yaml`, which refuses a blank `contract`/`address`/`networks` rather than looping zero times and exiting green. What this file *can* get wrong is its data — the artifact paths and the `networks` default — so both were checked against an independent oracle instead: (1) `arbitrum base base-sepolia mainnet flare hyperliquid polygon` are all seven accepted by `forge verify-contract --chain` (foundry nightly `43923a4`, from `rainix#sol-shell`); (2) `base_sepolia`, `ethereum` and `hyperevm` are all three rejected by that same binary with `error: invalid value '<name>' for '--chain <CHAIN>'`, before any network call — so the default is not merely plausible, the alias spellings it avoids are demonstrably fatal; (3) the file parses (`yq`); (4) the `route-processor` claim in the header is `grep`-checked, not assumed — no `contract RouteProcessor4` is declared anywhere under `src/`, `test/` or the remappings, only the pinned creation-code constant.
- Oracle: two independent sources that agree, neither of them this file. (1) The six deploy runs' own `manual verification command:` lines, printed by `LibRainDeploy` from the values it actually broadcast under, read out of the run logs linked in the table above. (2) The committed `src/generated/0_1_15/*.sol` `DEPLOYED_ADDRESS` constants and the `artifactPath` fields in `src/abstract/RaindexDeploySuites.sol`. All six artifact-path/address pairs match across both. For the chain names the oracle is foundry's own `--chain` parser, as above — not the docs, and not the rain.deploy template this was copied from.
- Category check: the ask is (a) add the `Manual sol verify` caller, (b) get the `networks` default onto FOUNDRY chain names rather than the RPC aliases. Covered a, b — (a) is the file, (b) is the default plus the input description that stops the next person copying `--chain` off the deploy's printed line. The `route-processor` note is not extra scope; it is the answer to "which contracts can this actually verify", surfaced because the six-suite set does not map one-to-one onto six dispatchable contracts. No contract is verified by this PR, only made verifiable.
