### PR TITLE
Verify the graph-node API schema snapshot in CI

### DIFF
--- a/.github/workflows/test-subgraph.yml
+++ b/.github/workflows/test-subgraph.yml
@@ -4,3 +4,49 @@ jobs:
   subgraph-test:
     uses: rainlanguage/rainix/.github/workflows/rainix-subgraph-test.yaml@main
     secrets: inherit
+  # `crates/subgraph/schema/raindex.graphql` is the graph-node API schema that
+  # `cynic_codegen` in `crates/subgraph/build.rs` registers as truth for the
+  # generated client, and nothing in this repo produces it. It cannot be
+  # regenerated offline the way `copy-artifacts` regenerates the ABIs, because
+  # deriving it means running graph-node's own schema derivation — so
+  # graph-node runs, here, against a throwaway store and an anvil chain.
+  schema-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          gc-max-store-size-linux: 1G
+      # anvil is the only thing this job wants out of a solidity shell: the
+      # ABIs the manifest names are committed under subgraph/abis, so unlike
+      # rainlanguage/rain.metadata#298 there is no soldeer install and no
+      # forge build here.
+      - name: Start anvil
+        run: |
+          nix develop .#sol-shell -c anvil --host 0.0.0.0 --chain-id 11155111 > anvil.log 2>&1 &
+          nix develop .#sol-shell -c bash -c 'for _ in $(seq 60); do cast block-number --rpc-url http://127.0.0.1:8545 && exit 0; sleep 1; done; exit 1'
+      - name: Start graph-node
+        run: |
+          docker compose -f subgraph/docker-compose.graph-node.yml up -d --wait
+          for _ in $(seq 60); do
+            curl -s -o /dev/null http://localhost:8020/ && exit 0
+            sleep 2
+          done
+          exit 1
+      - name: Deploy the subgraph and diff the committed API schema
+        run: nix develop .#subgraph-shell -c bash subgraph/check-api-schema.sh
+      - name: Upload the API schema graph-node derived
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: raindex-api-schema
+          path: raindex.graphql.generated
+          if-no-files-found: warn
+      - name: anvil log
+        if: failure()
+        run: cat anvil.log
+      - name: graph-node logs
+        if: failure()
+        run: docker compose -f subgraph/docker-compose.graph-node.yml logs
+      - name: The subgraph source carries no build residue
+        run: git diff --exit-code -- subgraph/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dependencies/
 
 # Local pre-commit hook config
 .pre-commit-config.yaml
+
+# The API schema the schema-snapshot job introspects out of graph-node
+raindex.graphql.generated

--- a/crates/subgraph/schema/raindex.graphql
+++ b/crates/subgraph/schema/raindex.graphql
@@ -1,218 +1,153 @@
 """
-Marks the GraphQL type as indexable entity.  Each type that should be an entity
-is required to be annotated with this directive.
-"""
-directive @entity on OBJECT
-
-"""
-Defined a Subgraph ID for an object type
-"""
-directive @subgraphId(id: String!) on OBJECT
-
-"""
 creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
 """
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
 
-type _Block_ {
-  """
-  The hash of the block
-  """
-  hash: Bytes
-
-  """
-  The block number
-  """
-  number: Int!
-
-  """
-  Integer representation of the timestamp stored in blocks for the chain
-  """
-  timestamp: Int
-
-  """
-  The hash of the parent block
-  """
-  parentHash: Bytes
-}
-
 """
-The type for the top-level _meta field
+Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.
 """
-type _Meta_ {
-  """
-  Information about a specific subgraph block. The hash of the block
-  will be null if the _meta field has a block constraint that asks for
-  a block number. It will be filled if the _meta field has no block constraint
-  and therefore asks for the latest  block
-  """
-  block: _Block_!
+directive @entity on OBJECT
 
-  """
-  The deployment ID
-  """
-  deployment: String!
-
-  """
-  If `true`, the subgraph encountered indexing errors at some past block
-  """
-  hasIndexingErrors: Boolean!
-}
-
-enum _SubgraphErrorPolicy_ {
-  """
-  Data will be returned even if the subgraph has indexing errors
-  """
-  allow
-
-  """
-  If the subgraph has indexing errors, data will be omitted. The default.
-  """
-  deny
-}
+"""Defined a Subgraph ID for an object type"""
+directive @subgraphId(id: String!) on OBJECT
 
 type AddOrder implements Event {
   id: Bytes!
 
-  """
-  The order that was added
-  """
+  """The order that was added"""
   order: Order!
 
-  """
-  The raindex this add order event is in
-  """
+  """The raindex this add order event is in"""
   raindex: Raindex!
-  transaction: Transaction!
 
-  """
-  The msg.sender of this add order call
-  """
+  """The msg.sender of this add order call"""
   sender: Bytes!
+  transaction: Transaction!
 }
 
 input AddOrder_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  order: String
-  order_not: String
-  order_gt: String
-  order_lt: String
-  order_gte: String
-  order_lte: String
-  order_in: [String!]
-  order_not_in: [String!]
-  order_contains: String
-  order_contains_nocase: String
-  order_not_contains: String
-  order_not_contains_nocase: String
-  order_starts_with: String
-  order_starts_with_nocase: String
-  order_not_starts_with: String
-  order_not_starts_with_nocase: String
-  order_ends_with: String
-  order_ends_with_nocase: String
-  order_not_ends_with: String
-  order_not_ends_with_nocase: String
-  order_: Order_filter
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [AddOrder_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   or: [AddOrder_filter]
+  order: String
+  order_: Order_filter
+  order_contains: String
+  order_contains_nocase: String
+  order_ends_with: String
+  order_ends_with_nocase: String
+  order_gt: String
+  order_gte: String
+  order_in: [String!]
+  order_lt: String
+  order_lte: String
+  order_not: String
+  order_not_contains: String
+  order_not_contains_nocase: String
+  order_not_ends_with: String
+  order_not_ends_with_nocase: String
+  order_not_in: [String!]
+  order_not_starts_with: String
+  order_not_starts_with_nocase: String
+  order_starts_with: String
+  order_starts_with_nocase: String
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
 enum AddOrder_orderBy {
   id
   order
-  order__id
   order__active
-  order__orderHash
-  order__owner
+  order__id
+  order__meta
   order__nonce
   order__orderBytes
-  order__meta
+  order__orderHash
+  order__owner
   order__timestampAdded
   raindex
   raindex__id
+  sender
   transaction
-  transaction__id
-  transaction__timestamp
   transaction__blockNumber
   transaction__from
-  sender
+  transaction__id
+  transaction__timestamp
 }
 
 enum Aggregation_interval {
-  hour
   day
+  hour
 }
 
 scalar BigDecimal
 
 scalar BigInt
+
+input BlockChangedFilter {
+  number_gte: Int!
+}
 
 input Block_height {
   hash: Bytes
@@ -220,1727 +155,1136 @@ input Block_height {
   number_gte: Int
 }
 
-input BlockChangedFilter {
-  number_gte: Int!
-}
-
 scalar Bytes
 
-type Clear implements TradeEvent {
-  id: Bytes!
+type Clear implements Event & TradeEvent {
+  """Alice bounty amount"""
+  aliceBountyAmount: Bytes!
+  aliceBountyVaultBalanceChange: ClearBounty
 
-  """
-  Alice input amount
-  """
+  """Alice input amount"""
   aliceInputAmount: Bytes!
 
-  """
-  Alice output amount
-  """
+  """Alice output amount"""
   aliceOutputAmount: Bytes!
 
-  """
-  Bob input amount
-  """
-  bobInputAmount: Bytes!
-
-  """
-  Bob output amount
-  """
-  bobOutputAmount: Bytes!
-
-  """
-  Alice bounty amount
-  """
-  aliceBountyAmount: Bytes!
-
-  """
-  Bob bounty amount
-  """
+  """Bob bounty amount"""
   bobBountyAmount: Bytes!
-  aliceBountyVaultBalanceChange: ClearBounty
   bobBountyVaultBalanceChange: ClearBounty
 
-  """
-  The raindex this trade event is for
-  """
+  """Bob input amount"""
+  bobInputAmount: Bytes!
+
+  """Bob output amount"""
+  bobOutputAmount: Bytes!
+  id: Bytes!
+
+  """The raindex this trade event is for"""
   raindex: Raindex!
 
-  """
-  The trades that occured in this event
-  """
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-  ): [Trade!]!
-  transaction: Transaction!
-
-  """
-  The msg.sender of this trade
-  """
+  """The msg.sender of this trade"""
   sender: Bytes!
-}
 
-input Clear_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  aliceInputAmount: Bytes
-  aliceInputAmount_not: Bytes
-  aliceInputAmount_gt: Bytes
-  aliceInputAmount_lt: Bytes
-  aliceInputAmount_gte: Bytes
-  aliceInputAmount_lte: Bytes
-  aliceInputAmount_in: [Bytes!]
-  aliceInputAmount_not_in: [Bytes!]
-  aliceInputAmount_contains: Bytes
-  aliceInputAmount_not_contains: Bytes
-  aliceOutputAmount: Bytes
-  aliceOutputAmount_not: Bytes
-  aliceOutputAmount_gt: Bytes
-  aliceOutputAmount_lt: Bytes
-  aliceOutputAmount_gte: Bytes
-  aliceOutputAmount_lte: Bytes
-  aliceOutputAmount_in: [Bytes!]
-  aliceOutputAmount_not_in: [Bytes!]
-  aliceOutputAmount_contains: Bytes
-  aliceOutputAmount_not_contains: Bytes
-  bobInputAmount: Bytes
-  bobInputAmount_not: Bytes
-  bobInputAmount_gt: Bytes
-  bobInputAmount_lt: Bytes
-  bobInputAmount_gte: Bytes
-  bobInputAmount_lte: Bytes
-  bobInputAmount_in: [Bytes!]
-  bobInputAmount_not_in: [Bytes!]
-  bobInputAmount_contains: Bytes
-  bobInputAmount_not_contains: Bytes
-  bobOutputAmount: Bytes
-  bobOutputAmount_not: Bytes
-  bobOutputAmount_gt: Bytes
-  bobOutputAmount_lt: Bytes
-  bobOutputAmount_gte: Bytes
-  bobOutputAmount_lte: Bytes
-  bobOutputAmount_in: [Bytes!]
-  bobOutputAmount_not_in: [Bytes!]
-  bobOutputAmount_contains: Bytes
-  bobOutputAmount_not_contains: Bytes
-  aliceBountyAmount: Bytes
-  aliceBountyAmount_not: Bytes
-  aliceBountyAmount_gt: Bytes
-  aliceBountyAmount_lt: Bytes
-  aliceBountyAmount_gte: Bytes
-  aliceBountyAmount_lte: Bytes
-  aliceBountyAmount_in: [Bytes!]
-  aliceBountyAmount_not_in: [Bytes!]
-  aliceBountyAmount_contains: Bytes
-  aliceBountyAmount_not_contains: Bytes
-  bobBountyAmount: Bytes
-  bobBountyAmount_not: Bytes
-  bobBountyAmount_gt: Bytes
-  bobBountyAmount_lt: Bytes
-  bobBountyAmount_gte: Bytes
-  bobBountyAmount_lte: Bytes
-  bobBountyAmount_in: [Bytes!]
-  bobBountyAmount_not_in: [Bytes!]
-  bobBountyAmount_contains: Bytes
-  bobBountyAmount_not_contains: Bytes
-  aliceBountyVaultBalanceChange: String
-  aliceBountyVaultBalanceChange_not: String
-  aliceBountyVaultBalanceChange_gt: String
-  aliceBountyVaultBalanceChange_lt: String
-  aliceBountyVaultBalanceChange_gte: String
-  aliceBountyVaultBalanceChange_lte: String
-  aliceBountyVaultBalanceChange_in: [String!]
-  aliceBountyVaultBalanceChange_not_in: [String!]
-  aliceBountyVaultBalanceChange_contains: String
-  aliceBountyVaultBalanceChange_contains_nocase: String
-  aliceBountyVaultBalanceChange_not_contains: String
-  aliceBountyVaultBalanceChange_not_contains_nocase: String
-  aliceBountyVaultBalanceChange_starts_with: String
-  aliceBountyVaultBalanceChange_starts_with_nocase: String
-  aliceBountyVaultBalanceChange_not_starts_with: String
-  aliceBountyVaultBalanceChange_not_starts_with_nocase: String
-  aliceBountyVaultBalanceChange_ends_with: String
-  aliceBountyVaultBalanceChange_ends_with_nocase: String
-  aliceBountyVaultBalanceChange_not_ends_with: String
-  aliceBountyVaultBalanceChange_not_ends_with_nocase: String
-  aliceBountyVaultBalanceChange_: ClearBounty_filter
-  bobBountyVaultBalanceChange: String
-  bobBountyVaultBalanceChange_not: String
-  bobBountyVaultBalanceChange_gt: String
-  bobBountyVaultBalanceChange_lt: String
-  bobBountyVaultBalanceChange_gte: String
-  bobBountyVaultBalanceChange_lte: String
-  bobBountyVaultBalanceChange_in: [String!]
-  bobBountyVaultBalanceChange_not_in: [String!]
-  bobBountyVaultBalanceChange_contains: String
-  bobBountyVaultBalanceChange_contains_nocase: String
-  bobBountyVaultBalanceChange_not_contains: String
-  bobBountyVaultBalanceChange_not_contains_nocase: String
-  bobBountyVaultBalanceChange_starts_with: String
-  bobBountyVaultBalanceChange_starts_with_nocase: String
-  bobBountyVaultBalanceChange_not_starts_with: String
-  bobBountyVaultBalanceChange_not_starts_with_nocase: String
-  bobBountyVaultBalanceChange_ends_with: String
-  bobBountyVaultBalanceChange_ends_with_nocase: String
-  bobBountyVaultBalanceChange_not_ends_with: String
-  bobBountyVaultBalanceChange_not_ends_with_nocase: String
-  bobBountyVaultBalanceChange_: ClearBounty_filter
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  trades_: Trade_filter
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Clear_filter]
-  or: [Clear_filter]
-}
-
-enum Clear_orderBy {
-  id
-  aliceInputAmount
-  aliceOutputAmount
-  bobInputAmount
-  bobOutputAmount
-  aliceBountyAmount
-  bobBountyAmount
-  aliceBountyVaultBalanceChange
-  aliceBountyVaultBalanceChange__id
-  aliceBountyVaultBalanceChange__sender
-  aliceBountyVaultBalanceChange__amount
-  aliceBountyVaultBalanceChange__oldVaultBalance
-  aliceBountyVaultBalanceChange__newVaultBalance
-  aliceBountyVaultBalanceChange__timestamp
-  bobBountyVaultBalanceChange
-  bobBountyVaultBalanceChange__id
-  bobBountyVaultBalanceChange__sender
-  bobBountyVaultBalanceChange__amount
-  bobBountyVaultBalanceChange__oldVaultBalance
-  bobBountyVaultBalanceChange__newVaultBalance
-  bobBountyVaultBalanceChange__timestamp
-  raindex
-  raindex__id
-  trades
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
-  sender
+  """The trades that occured in this event"""
+  trades(first: Int = 100, orderBy: Trade_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Trade_filter): [Trade!]!
+  transaction: Transaction!
 }
 
 type ClearBounty implements VaultBalanceChange {
+  """The amount that was changed - this is signed"""
+  amount: Bytes!
   id: Bytes!
 
-  """
-  The raindex this balance change is for
-  """
-  raindex: Raindex!
-
-  """
-  The msg.sender of this clear call and owner of the vault
-  """
-  sender: Bytes!
-
-  """
-  The vault that was affected
-  """
-  vault: Vault!
-
-  """
-  The amount that was changed - this is signed
-  """
-  amount: Bytes!
-
-  """
-  The balance of the vault before the change
-  """
-  oldVaultBalance: Bytes!
-
-  """
-  The balance of the vault after the change
-  """
+  """The balance of the vault after the change"""
   newVaultBalance: Bytes!
 
-  """
-  The timestamp this balance change was executed
-  """
+  """The balance of the vault before the change"""
+  oldVaultBalance: Bytes!
+
+  """The raindex this balance change is for"""
+  raindex: Raindex!
+
+  """The msg.sender of this clear call and owner of the vault"""
+  sender: Bytes!
+
+  """The timestamp this balance change was executed"""
   timestamp: BigInt!
 
-  """
-  The transaction in which this balance change was executed
-  """
+  """The transaction in which this balance change was executed"""
   transaction: Transaction!
+
+  """The vault that was affected"""
+  vault: Vault!
 }
 
 input ClearBounty_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  amount: Bytes
+  amount_contains: Bytes
+  amount_gt: Bytes
+  amount_gte: Bytes
+  amount_in: [Bytes!]
+  amount_lt: Bytes
+  amount_lte: Bytes
+  amount_not: Bytes
+  amount_not_contains: Bytes
+  amount_not_in: [Bytes!]
+  and: [ClearBounty_filter]
   id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
   id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
   id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  newVaultBalance: Bytes
+  newVaultBalance_contains: Bytes
+  newVaultBalance_gt: Bytes
+  newVaultBalance_gte: Bytes
+  newVaultBalance_in: [Bytes!]
+  newVaultBalance_lt: Bytes
+  newVaultBalance_lte: Bytes
+  newVaultBalance_not: Bytes
+  newVaultBalance_not_contains: Bytes
+  newVaultBalance_not_in: [Bytes!]
+  oldVaultBalance: Bytes
+  oldVaultBalance_contains: Bytes
+  oldVaultBalance_gt: Bytes
+  oldVaultBalance_gte: Bytes
+  oldVaultBalance_in: [Bytes!]
+  oldVaultBalance_lt: Bytes
+  oldVaultBalance_lte: Bytes
+  oldVaultBalance_not: Bytes
+  oldVaultBalance_not_contains: Bytes
+  oldVaultBalance_not_in: [Bytes!]
+  or: [ClearBounty_filter]
   raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
+  raindex_: Raindex_filter
   raindex_contains: String
   raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
   raindex_ends_with: String
   raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
   raindex_not_ends_with: String
   raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
   sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
   sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
   sender_not_contains: Bytes
-  vault: String
-  vault_not: String
-  vault_gt: String
-  vault_lt: String
-  vault_gte: String
-  vault_lte: String
-  vault_in: [String!]
-  vault_not_in: [String!]
-  vault_contains: String
-  vault_contains_nocase: String
-  vault_not_contains: String
-  vault_not_contains_nocase: String
-  vault_starts_with: String
-  vault_starts_with_nocase: String
-  vault_not_starts_with: String
-  vault_not_starts_with_nocase: String
-  vault_ends_with: String
-  vault_ends_with_nocase: String
-  vault_not_ends_with: String
-  vault_not_ends_with_nocase: String
-  vault_: Vault_filter
-  amount: Bytes
-  amount_not: Bytes
-  amount_gt: Bytes
-  amount_lt: Bytes
-  amount_gte: Bytes
-  amount_lte: Bytes
-  amount_in: [Bytes!]
-  amount_not_in: [Bytes!]
-  amount_contains: Bytes
-  amount_not_contains: Bytes
-  oldVaultBalance: Bytes
-  oldVaultBalance_not: Bytes
-  oldVaultBalance_gt: Bytes
-  oldVaultBalance_lt: Bytes
-  oldVaultBalance_gte: Bytes
-  oldVaultBalance_lte: Bytes
-  oldVaultBalance_in: [Bytes!]
-  oldVaultBalance_not_in: [Bytes!]
-  oldVaultBalance_contains: Bytes
-  oldVaultBalance_not_contains: Bytes
-  newVaultBalance: Bytes
-  newVaultBalance_not: Bytes
-  newVaultBalance_gt: Bytes
-  newVaultBalance_lt: Bytes
-  newVaultBalance_gte: Bytes
-  newVaultBalance_lte: Bytes
-  newVaultBalance_in: [Bytes!]
-  newVaultBalance_not_in: [Bytes!]
-  newVaultBalance_contains: Bytes
-  newVaultBalance_not_contains: Bytes
+  sender_not_in: [Bytes!]
   timestamp: BigInt
-  timestamp_not: BigInt
   timestamp_gt: BigInt
-  timestamp_lt: BigInt
   timestamp_gte: BigInt
-  timestamp_lte: BigInt
   timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
   timestamp_not_in: [BigInt!]
   transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
+  transaction_: Transaction_filter
   transaction_contains: String
   transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
   transaction_ends_with: String
   transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
   transaction_not_ends_with: String
   transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [ClearBounty_filter]
-  or: [ClearBounty_filter]
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
+  vault: String
+  vault_: Vault_filter
+  vault_contains: String
+  vault_contains_nocase: String
+  vault_ends_with: String
+  vault_ends_with_nocase: String
+  vault_gt: String
+  vault_gte: String
+  vault_in: [String!]
+  vault_lt: String
+  vault_lte: String
+  vault_not: String
+  vault_not_contains: String
+  vault_not_contains_nocase: String
+  vault_not_ends_with: String
+  vault_not_ends_with_nocase: String
+  vault_not_in: [String!]
+  vault_not_starts_with: String
+  vault_not_starts_with_nocase: String
+  vault_starts_with: String
+  vault_starts_with_nocase: String
 }
 
 enum ClearBounty_orderBy {
+  amount
   id
+  newVaultBalance
+  oldVaultBalance
   raindex
   raindex__id
   sender
+  timestamp
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
   vault
+  vault__balance
   vault__id
   vault__owner
   vault__vaultId
-  vault__balance
-  amount
-  oldVaultBalance
-  newVaultBalance
-  timestamp
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
 }
 
 type ClearTemporaryData {
-  id: Bytes!
-  aliceOrderHash: Bytes!
   aliceAddress: Bytes!
-  aliceInputVaultId: Bytes!
-  aliceInputToken: Bytes!
-  aliceOutputVaultId: Bytes!
-  aliceOutputToken: Bytes!
   aliceBounty: Bytes!
-  bobOrderHash: Bytes!
+  aliceInputToken: Bytes!
+  aliceInputVaultId: Bytes!
+  aliceOrderHash: Bytes!
+  aliceOutputToken: Bytes!
+  aliceOutputVaultId: Bytes!
   bobAddress: Bytes!
-  bobInputVaultId: Bytes!
-  bobInputToken: Bytes!
-  bobOutputVaultId: Bytes!
-  bobOutputToken: Bytes!
   bobBounty: Bytes!
+  bobInputToken: Bytes!
+  bobInputVaultId: Bytes!
+  bobOrderHash: Bytes!
+  bobOutputToken: Bytes!
+  bobOutputVaultId: Bytes!
+  id: Bytes!
 }
 
 input ClearTemporaryData_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  aliceOrderHash: Bytes
-  aliceOrderHash_not: Bytes
-  aliceOrderHash_gt: Bytes
-  aliceOrderHash_lt: Bytes
-  aliceOrderHash_gte: Bytes
-  aliceOrderHash_lte: Bytes
-  aliceOrderHash_in: [Bytes!]
-  aliceOrderHash_not_in: [Bytes!]
-  aliceOrderHash_contains: Bytes
-  aliceOrderHash_not_contains: Bytes
-  aliceAddress: Bytes
-  aliceAddress_not: Bytes
-  aliceAddress_gt: Bytes
-  aliceAddress_lt: Bytes
-  aliceAddress_gte: Bytes
-  aliceAddress_lte: Bytes
-  aliceAddress_in: [Bytes!]
-  aliceAddress_not_in: [Bytes!]
-  aliceAddress_contains: Bytes
-  aliceAddress_not_contains: Bytes
-  aliceInputVaultId: Bytes
-  aliceInputVaultId_not: Bytes
-  aliceInputVaultId_gt: Bytes
-  aliceInputVaultId_lt: Bytes
-  aliceInputVaultId_gte: Bytes
-  aliceInputVaultId_lte: Bytes
-  aliceInputVaultId_in: [Bytes!]
-  aliceInputVaultId_not_in: [Bytes!]
-  aliceInputVaultId_contains: Bytes
-  aliceInputVaultId_not_contains: Bytes
-  aliceInputToken: Bytes
-  aliceInputToken_not: Bytes
-  aliceInputToken_gt: Bytes
-  aliceInputToken_lt: Bytes
-  aliceInputToken_gte: Bytes
-  aliceInputToken_lte: Bytes
-  aliceInputToken_in: [Bytes!]
-  aliceInputToken_not_in: [Bytes!]
-  aliceInputToken_contains: Bytes
-  aliceInputToken_not_contains: Bytes
-  aliceOutputVaultId: Bytes
-  aliceOutputVaultId_not: Bytes
-  aliceOutputVaultId_gt: Bytes
-  aliceOutputVaultId_lt: Bytes
-  aliceOutputVaultId_gte: Bytes
-  aliceOutputVaultId_lte: Bytes
-  aliceOutputVaultId_in: [Bytes!]
-  aliceOutputVaultId_not_in: [Bytes!]
-  aliceOutputVaultId_contains: Bytes
-  aliceOutputVaultId_not_contains: Bytes
-  aliceOutputToken: Bytes
-  aliceOutputToken_not: Bytes
-  aliceOutputToken_gt: Bytes
-  aliceOutputToken_lt: Bytes
-  aliceOutputToken_gte: Bytes
-  aliceOutputToken_lte: Bytes
-  aliceOutputToken_in: [Bytes!]
-  aliceOutputToken_not_in: [Bytes!]
-  aliceOutputToken_contains: Bytes
-  aliceOutputToken_not_contains: Bytes
-  aliceBounty: Bytes
-  aliceBounty_not: Bytes
-  aliceBounty_gt: Bytes
-  aliceBounty_lt: Bytes
-  aliceBounty_gte: Bytes
-  aliceBounty_lte: Bytes
-  aliceBounty_in: [Bytes!]
-  aliceBounty_not_in: [Bytes!]
-  aliceBounty_contains: Bytes
-  aliceBounty_not_contains: Bytes
-  bobOrderHash: Bytes
-  bobOrderHash_not: Bytes
-  bobOrderHash_gt: Bytes
-  bobOrderHash_lt: Bytes
-  bobOrderHash_gte: Bytes
-  bobOrderHash_lte: Bytes
-  bobOrderHash_in: [Bytes!]
-  bobOrderHash_not_in: [Bytes!]
-  bobOrderHash_contains: Bytes
-  bobOrderHash_not_contains: Bytes
-  bobAddress: Bytes
-  bobAddress_not: Bytes
-  bobAddress_gt: Bytes
-  bobAddress_lt: Bytes
-  bobAddress_gte: Bytes
-  bobAddress_lte: Bytes
-  bobAddress_in: [Bytes!]
-  bobAddress_not_in: [Bytes!]
-  bobAddress_contains: Bytes
-  bobAddress_not_contains: Bytes
-  bobInputVaultId: Bytes
-  bobInputVaultId_not: Bytes
-  bobInputVaultId_gt: Bytes
-  bobInputVaultId_lt: Bytes
-  bobInputVaultId_gte: Bytes
-  bobInputVaultId_lte: Bytes
-  bobInputVaultId_in: [Bytes!]
-  bobInputVaultId_not_in: [Bytes!]
-  bobInputVaultId_contains: Bytes
-  bobInputVaultId_not_contains: Bytes
-  bobInputToken: Bytes
-  bobInputToken_not: Bytes
-  bobInputToken_gt: Bytes
-  bobInputToken_lt: Bytes
-  bobInputToken_gte: Bytes
-  bobInputToken_lte: Bytes
-  bobInputToken_in: [Bytes!]
-  bobInputToken_not_in: [Bytes!]
-  bobInputToken_contains: Bytes
-  bobInputToken_not_contains: Bytes
-  bobOutputVaultId: Bytes
-  bobOutputVaultId_not: Bytes
-  bobOutputVaultId_gt: Bytes
-  bobOutputVaultId_lt: Bytes
-  bobOutputVaultId_gte: Bytes
-  bobOutputVaultId_lte: Bytes
-  bobOutputVaultId_in: [Bytes!]
-  bobOutputVaultId_not_in: [Bytes!]
-  bobOutputVaultId_contains: Bytes
-  bobOutputVaultId_not_contains: Bytes
-  bobOutputToken: Bytes
-  bobOutputToken_not: Bytes
-  bobOutputToken_gt: Bytes
-  bobOutputToken_lt: Bytes
-  bobOutputToken_gte: Bytes
-  bobOutputToken_lte: Bytes
-  bobOutputToken_in: [Bytes!]
-  bobOutputToken_not_in: [Bytes!]
-  bobOutputToken_contains: Bytes
-  bobOutputToken_not_contains: Bytes
-  bobBounty: Bytes
-  bobBounty_not: Bytes
-  bobBounty_gt: Bytes
-  bobBounty_lt: Bytes
-  bobBounty_gte: Bytes
-  bobBounty_lte: Bytes
-  bobBounty_in: [Bytes!]
-  bobBounty_not_in: [Bytes!]
-  bobBounty_contains: Bytes
-  bobBounty_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  aliceAddress: Bytes
+  aliceAddress_contains: Bytes
+  aliceAddress_gt: Bytes
+  aliceAddress_gte: Bytes
+  aliceAddress_in: [Bytes!]
+  aliceAddress_lt: Bytes
+  aliceAddress_lte: Bytes
+  aliceAddress_not: Bytes
+  aliceAddress_not_contains: Bytes
+  aliceAddress_not_in: [Bytes!]
+  aliceBounty: Bytes
+  aliceBounty_contains: Bytes
+  aliceBounty_gt: Bytes
+  aliceBounty_gte: Bytes
+  aliceBounty_in: [Bytes!]
+  aliceBounty_lt: Bytes
+  aliceBounty_lte: Bytes
+  aliceBounty_not: Bytes
+  aliceBounty_not_contains: Bytes
+  aliceBounty_not_in: [Bytes!]
+  aliceInputToken: Bytes
+  aliceInputToken_contains: Bytes
+  aliceInputToken_gt: Bytes
+  aliceInputToken_gte: Bytes
+  aliceInputToken_in: [Bytes!]
+  aliceInputToken_lt: Bytes
+  aliceInputToken_lte: Bytes
+  aliceInputToken_not: Bytes
+  aliceInputToken_not_contains: Bytes
+  aliceInputToken_not_in: [Bytes!]
+  aliceInputVaultId: Bytes
+  aliceInputVaultId_contains: Bytes
+  aliceInputVaultId_gt: Bytes
+  aliceInputVaultId_gte: Bytes
+  aliceInputVaultId_in: [Bytes!]
+  aliceInputVaultId_lt: Bytes
+  aliceInputVaultId_lte: Bytes
+  aliceInputVaultId_not: Bytes
+  aliceInputVaultId_not_contains: Bytes
+  aliceInputVaultId_not_in: [Bytes!]
+  aliceOrderHash: Bytes
+  aliceOrderHash_contains: Bytes
+  aliceOrderHash_gt: Bytes
+  aliceOrderHash_gte: Bytes
+  aliceOrderHash_in: [Bytes!]
+  aliceOrderHash_lt: Bytes
+  aliceOrderHash_lte: Bytes
+  aliceOrderHash_not: Bytes
+  aliceOrderHash_not_contains: Bytes
+  aliceOrderHash_not_in: [Bytes!]
+  aliceOutputToken: Bytes
+  aliceOutputToken_contains: Bytes
+  aliceOutputToken_gt: Bytes
+  aliceOutputToken_gte: Bytes
+  aliceOutputToken_in: [Bytes!]
+  aliceOutputToken_lt: Bytes
+  aliceOutputToken_lte: Bytes
+  aliceOutputToken_not: Bytes
+  aliceOutputToken_not_contains: Bytes
+  aliceOutputToken_not_in: [Bytes!]
+  aliceOutputVaultId: Bytes
+  aliceOutputVaultId_contains: Bytes
+  aliceOutputVaultId_gt: Bytes
+  aliceOutputVaultId_gte: Bytes
+  aliceOutputVaultId_in: [Bytes!]
+  aliceOutputVaultId_lt: Bytes
+  aliceOutputVaultId_lte: Bytes
+  aliceOutputVaultId_not: Bytes
+  aliceOutputVaultId_not_contains: Bytes
+  aliceOutputVaultId_not_in: [Bytes!]
   and: [ClearTemporaryData_filter]
+  bobAddress: Bytes
+  bobAddress_contains: Bytes
+  bobAddress_gt: Bytes
+  bobAddress_gte: Bytes
+  bobAddress_in: [Bytes!]
+  bobAddress_lt: Bytes
+  bobAddress_lte: Bytes
+  bobAddress_not: Bytes
+  bobAddress_not_contains: Bytes
+  bobAddress_not_in: [Bytes!]
+  bobBounty: Bytes
+  bobBounty_contains: Bytes
+  bobBounty_gt: Bytes
+  bobBounty_gte: Bytes
+  bobBounty_in: [Bytes!]
+  bobBounty_lt: Bytes
+  bobBounty_lte: Bytes
+  bobBounty_not: Bytes
+  bobBounty_not_contains: Bytes
+  bobBounty_not_in: [Bytes!]
+  bobInputToken: Bytes
+  bobInputToken_contains: Bytes
+  bobInputToken_gt: Bytes
+  bobInputToken_gte: Bytes
+  bobInputToken_in: [Bytes!]
+  bobInputToken_lt: Bytes
+  bobInputToken_lte: Bytes
+  bobInputToken_not: Bytes
+  bobInputToken_not_contains: Bytes
+  bobInputToken_not_in: [Bytes!]
+  bobInputVaultId: Bytes
+  bobInputVaultId_contains: Bytes
+  bobInputVaultId_gt: Bytes
+  bobInputVaultId_gte: Bytes
+  bobInputVaultId_in: [Bytes!]
+  bobInputVaultId_lt: Bytes
+  bobInputVaultId_lte: Bytes
+  bobInputVaultId_not: Bytes
+  bobInputVaultId_not_contains: Bytes
+  bobInputVaultId_not_in: [Bytes!]
+  bobOrderHash: Bytes
+  bobOrderHash_contains: Bytes
+  bobOrderHash_gt: Bytes
+  bobOrderHash_gte: Bytes
+  bobOrderHash_in: [Bytes!]
+  bobOrderHash_lt: Bytes
+  bobOrderHash_lte: Bytes
+  bobOrderHash_not: Bytes
+  bobOrderHash_not_contains: Bytes
+  bobOrderHash_not_in: [Bytes!]
+  bobOutputToken: Bytes
+  bobOutputToken_contains: Bytes
+  bobOutputToken_gt: Bytes
+  bobOutputToken_gte: Bytes
+  bobOutputToken_in: [Bytes!]
+  bobOutputToken_lt: Bytes
+  bobOutputToken_lte: Bytes
+  bobOutputToken_not: Bytes
+  bobOutputToken_not_contains: Bytes
+  bobOutputToken_not_in: [Bytes!]
+  bobOutputVaultId: Bytes
+  bobOutputVaultId_contains: Bytes
+  bobOutputVaultId_gt: Bytes
+  bobOutputVaultId_gte: Bytes
+  bobOutputVaultId_in: [Bytes!]
+  bobOutputVaultId_lt: Bytes
+  bobOutputVaultId_lte: Bytes
+  bobOutputVaultId_not: Bytes
+  bobOutputVaultId_not_contains: Bytes
+  bobOutputVaultId_not_in: [Bytes!]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   or: [ClearTemporaryData_filter]
 }
 
 enum ClearTemporaryData_orderBy {
-  id
-  aliceOrderHash
   aliceAddress
-  aliceInputVaultId
-  aliceInputToken
-  aliceOutputVaultId
-  aliceOutputToken
   aliceBounty
-  bobOrderHash
+  aliceInputToken
+  aliceInputVaultId
+  aliceOrderHash
+  aliceOutputToken
+  aliceOutputVaultId
   bobAddress
-  bobInputVaultId
-  bobInputToken
-  bobOutputVaultId
-  bobOutputToken
   bobBounty
+  bobInputToken
+  bobInputVaultId
+  bobOrderHash
+  bobOutputToken
+  bobOutputVaultId
+  id
 }
 
-type Deposit implements Event & VaultBalanceChange {
-  id: Bytes!
-
-  """
-  The raindex this balance change is for
-  """
-  raindex: Raindex!
-
-  """
-  The vault that was deposited into
-  """
-  vault: Vault!
-
-  """
-  The amount that was deposited
-  """
-  amount: Bytes!
-  oldVaultBalance: Bytes!
-  newVaultBalance: Bytes!
-
-  """
-  The timestamp this balance change was executed
-  """
-  timestamp: BigInt!
-  transaction: Transaction!
-
-  """
-  The msg.sender of this withdrawal
-  """
-  sender: Bytes!
-}
-
-input Deposit_filter {
+input Clear_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  aliceBountyAmount: Bytes
+  aliceBountyAmount_contains: Bytes
+  aliceBountyAmount_gt: Bytes
+  aliceBountyAmount_gte: Bytes
+  aliceBountyAmount_in: [Bytes!]
+  aliceBountyAmount_lt: Bytes
+  aliceBountyAmount_lte: Bytes
+  aliceBountyAmount_not: Bytes
+  aliceBountyAmount_not_contains: Bytes
+  aliceBountyAmount_not_in: [Bytes!]
+  aliceBountyVaultBalanceChange: String
+  aliceBountyVaultBalanceChange_: ClearBounty_filter
+  aliceBountyVaultBalanceChange_contains: String
+  aliceBountyVaultBalanceChange_contains_nocase: String
+  aliceBountyVaultBalanceChange_ends_with: String
+  aliceBountyVaultBalanceChange_ends_with_nocase: String
+  aliceBountyVaultBalanceChange_gt: String
+  aliceBountyVaultBalanceChange_gte: String
+  aliceBountyVaultBalanceChange_in: [String!]
+  aliceBountyVaultBalanceChange_lt: String
+  aliceBountyVaultBalanceChange_lte: String
+  aliceBountyVaultBalanceChange_not: String
+  aliceBountyVaultBalanceChange_not_contains: String
+  aliceBountyVaultBalanceChange_not_contains_nocase: String
+  aliceBountyVaultBalanceChange_not_ends_with: String
+  aliceBountyVaultBalanceChange_not_ends_with_nocase: String
+  aliceBountyVaultBalanceChange_not_in: [String!]
+  aliceBountyVaultBalanceChange_not_starts_with: String
+  aliceBountyVaultBalanceChange_not_starts_with_nocase: String
+  aliceBountyVaultBalanceChange_starts_with: String
+  aliceBountyVaultBalanceChange_starts_with_nocase: String
+  aliceInputAmount: Bytes
+  aliceInputAmount_contains: Bytes
+  aliceInputAmount_gt: Bytes
+  aliceInputAmount_gte: Bytes
+  aliceInputAmount_in: [Bytes!]
+  aliceInputAmount_lt: Bytes
+  aliceInputAmount_lte: Bytes
+  aliceInputAmount_not: Bytes
+  aliceInputAmount_not_contains: Bytes
+  aliceInputAmount_not_in: [Bytes!]
+  aliceOutputAmount: Bytes
+  aliceOutputAmount_contains: Bytes
+  aliceOutputAmount_gt: Bytes
+  aliceOutputAmount_gte: Bytes
+  aliceOutputAmount_in: [Bytes!]
+  aliceOutputAmount_lt: Bytes
+  aliceOutputAmount_lte: Bytes
+  aliceOutputAmount_not: Bytes
+  aliceOutputAmount_not_contains: Bytes
+  aliceOutputAmount_not_in: [Bytes!]
+  and: [Clear_filter]
+  bobBountyAmount: Bytes
+  bobBountyAmount_contains: Bytes
+  bobBountyAmount_gt: Bytes
+  bobBountyAmount_gte: Bytes
+  bobBountyAmount_in: [Bytes!]
+  bobBountyAmount_lt: Bytes
+  bobBountyAmount_lte: Bytes
+  bobBountyAmount_not: Bytes
+  bobBountyAmount_not_contains: Bytes
+  bobBountyAmount_not_in: [Bytes!]
+  bobBountyVaultBalanceChange: String
+  bobBountyVaultBalanceChange_: ClearBounty_filter
+  bobBountyVaultBalanceChange_contains: String
+  bobBountyVaultBalanceChange_contains_nocase: String
+  bobBountyVaultBalanceChange_ends_with: String
+  bobBountyVaultBalanceChange_ends_with_nocase: String
+  bobBountyVaultBalanceChange_gt: String
+  bobBountyVaultBalanceChange_gte: String
+  bobBountyVaultBalanceChange_in: [String!]
+  bobBountyVaultBalanceChange_lt: String
+  bobBountyVaultBalanceChange_lte: String
+  bobBountyVaultBalanceChange_not: String
+  bobBountyVaultBalanceChange_not_contains: String
+  bobBountyVaultBalanceChange_not_contains_nocase: String
+  bobBountyVaultBalanceChange_not_ends_with: String
+  bobBountyVaultBalanceChange_not_ends_with_nocase: String
+  bobBountyVaultBalanceChange_not_in: [String!]
+  bobBountyVaultBalanceChange_not_starts_with: String
+  bobBountyVaultBalanceChange_not_starts_with_nocase: String
+  bobBountyVaultBalanceChange_starts_with: String
+  bobBountyVaultBalanceChange_starts_with_nocase: String
+  bobInputAmount: Bytes
+  bobInputAmount_contains: Bytes
+  bobInputAmount_gt: Bytes
+  bobInputAmount_gte: Bytes
+  bobInputAmount_in: [Bytes!]
+  bobInputAmount_lt: Bytes
+  bobInputAmount_lte: Bytes
+  bobInputAmount_not: Bytes
+  bobInputAmount_not_contains: Bytes
+  bobInputAmount_not_in: [Bytes!]
+  bobOutputAmount: Bytes
+  bobOutputAmount_contains: Bytes
+  bobOutputAmount_gt: Bytes
+  bobOutputAmount_gte: Bytes
+  bobOutputAmount_in: [Bytes!]
+  bobOutputAmount_lt: Bytes
+  bobOutputAmount_lte: Bytes
+  bobOutputAmount_not: Bytes
+  bobOutputAmount_not_contains: Bytes
+  bobOutputAmount_not_in: [Bytes!]
   id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
   id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
   id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  or: [Clear_filter]
   raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
+  raindex_: Raindex_filter
   raindex_contains: String
   raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
   raindex_ends_with: String
   raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
   raindex_not_ends_with: String
   raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  vault: String
-  vault_not: String
-  vault_gt: String
-  vault_lt: String
-  vault_gte: String
-  vault_lte: String
-  vault_in: [String!]
-  vault_not_in: [String!]
-  vault_contains: String
-  vault_contains_nocase: String
-  vault_not_contains: String
-  vault_not_contains_nocase: String
-  vault_starts_with: String
-  vault_starts_with_nocase: String
-  vault_not_starts_with: String
-  vault_not_starts_with_nocase: String
-  vault_ends_with: String
-  vault_ends_with_nocase: String
-  vault_not_ends_with: String
-  vault_not_ends_with_nocase: String
-  vault_: Vault_filter
-  amount: Bytes
-  amount_not: Bytes
-  amount_gt: Bytes
-  amount_lt: Bytes
-  amount_gte: Bytes
-  amount_lte: Bytes
-  amount_in: [Bytes!]
-  amount_not_in: [Bytes!]
-  amount_contains: Bytes
-  amount_not_contains: Bytes
-  oldVaultBalance: Bytes
-  oldVaultBalance_not: Bytes
-  oldVaultBalance_gt: Bytes
-  oldVaultBalance_lt: Bytes
-  oldVaultBalance_gte: Bytes
-  oldVaultBalance_lte: Bytes
-  oldVaultBalance_in: [Bytes!]
-  oldVaultBalance_not_in: [Bytes!]
-  oldVaultBalance_contains: Bytes
-  oldVaultBalance_not_contains: Bytes
-  newVaultBalance: Bytes
-  newVaultBalance_not: Bytes
-  newVaultBalance_gt: Bytes
-  newVaultBalance_lt: Bytes
-  newVaultBalance_gte: Bytes
-  newVaultBalance_lte: Bytes
-  newVaultBalance_in: [Bytes!]
-  newVaultBalance_not_in: [Bytes!]
-  newVaultBalance_contains: Bytes
-  newVaultBalance_not_contains: Bytes
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  trades_: Trade_filter
   transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
+  transaction_: Transaction_filter
   transaction_contains: String
   transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
   transaction_ends_with: String
   transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
   transaction_not_ends_with: String
   transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Deposit_filter]
-  or: [Deposit_filter]
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
-enum Deposit_orderBy {
+enum Clear_orderBy {
+  aliceBountyAmount
+  aliceBountyVaultBalanceChange
+  aliceBountyVaultBalanceChange__amount
+  aliceBountyVaultBalanceChange__id
+  aliceBountyVaultBalanceChange__newVaultBalance
+  aliceBountyVaultBalanceChange__oldVaultBalance
+  aliceBountyVaultBalanceChange__sender
+  aliceBountyVaultBalanceChange__timestamp
+  aliceInputAmount
+  aliceOutputAmount
+  bobBountyAmount
+  bobBountyVaultBalanceChange
+  bobBountyVaultBalanceChange__amount
+  bobBountyVaultBalanceChange__id
+  bobBountyVaultBalanceChange__newVaultBalance
+  bobBountyVaultBalanceChange__oldVaultBalance
+  bobBountyVaultBalanceChange__sender
+  bobBountyVaultBalanceChange__timestamp
+  bobInputAmount
+  bobOutputAmount
   id
   raindex
   raindex__id
+  sender
+  trades
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
+}
+
+type Deposit implements Event & VaultBalanceChange {
+  """The amount that was deposited"""
+  amount: Bytes!
+  id: Bytes!
+  newVaultBalance: Bytes!
+  oldVaultBalance: Bytes!
+
+  """The raindex this balance change is for"""
+  raindex: Raindex!
+
+  """The msg.sender of this withdrawal"""
+  sender: Bytes!
+
+  """The timestamp this balance change was executed"""
+  timestamp: BigInt!
+  transaction: Transaction!
+
+  """The vault that was deposited into"""
+  vault: Vault!
+}
+
+input Deposit_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  amount: Bytes
+  amount_contains: Bytes
+  amount_gt: Bytes
+  amount_gte: Bytes
+  amount_in: [Bytes!]
+  amount_lt: Bytes
+  amount_lte: Bytes
+  amount_not: Bytes
+  amount_not_contains: Bytes
+  amount_not_in: [Bytes!]
+  and: [Deposit_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  newVaultBalance: Bytes
+  newVaultBalance_contains: Bytes
+  newVaultBalance_gt: Bytes
+  newVaultBalance_gte: Bytes
+  newVaultBalance_in: [Bytes!]
+  newVaultBalance_lt: Bytes
+  newVaultBalance_lte: Bytes
+  newVaultBalance_not: Bytes
+  newVaultBalance_not_contains: Bytes
+  newVaultBalance_not_in: [Bytes!]
+  oldVaultBalance: Bytes
+  oldVaultBalance_contains: Bytes
+  oldVaultBalance_gt: Bytes
+  oldVaultBalance_gte: Bytes
+  oldVaultBalance_in: [Bytes!]
+  oldVaultBalance_lt: Bytes
+  oldVaultBalance_lte: Bytes
+  oldVaultBalance_not: Bytes
+  oldVaultBalance_not_contains: Bytes
+  oldVaultBalance_not_in: [Bytes!]
+  or: [Deposit_filter]
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  timestamp: BigInt
+  timestamp_gt: BigInt
+  timestamp_gte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
+  timestamp_not_in: [BigInt!]
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
+  vault: String
+  vault_: Vault_filter
+  vault_contains: String
+  vault_contains_nocase: String
+  vault_ends_with: String
+  vault_ends_with_nocase: String
+  vault_gt: String
+  vault_gte: String
+  vault_in: [String!]
+  vault_lt: String
+  vault_lte: String
+  vault_not: String
+  vault_not_contains: String
+  vault_not_contains_nocase: String
+  vault_not_ends_with: String
+  vault_not_ends_with_nocase: String
+  vault_not_in: [String!]
+  vault_not_starts_with: String
+  vault_not_starts_with_nocase: String
+  vault_starts_with: String
+  vault_starts_with_nocase: String
+}
+
+enum Deposit_orderBy {
+  amount
+  id
+  newVaultBalance
+  oldVaultBalance
+  raindex
+  raindex__id
+  sender
+  timestamp
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
   vault
+  vault__balance
   vault__id
   vault__owner
   vault__vaultId
-  vault__balance
-  amount
-  oldVaultBalance
-  newVaultBalance
-  timestamp
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
-  sender
 }
 
 type ERC20 {
-  id: Bytes!
-
-  """
-  The address of the ERC20 token
-  """
+  """The address of the ERC20 token"""
   address: Bytes!
 
-  """
-  The name of the ERC20 token
-  """
+  """The number of decimals of the ERC20 token"""
+  decimals: BigInt
+  id: Bytes!
+
+  """The name of the ERC20 token"""
   name: String
 
-  """
-  The symbol of the ERC20 token
-  """
+  """The symbol of the ERC20 token"""
   symbol: String
-
-  """
-  The number of decimals of the ERC20 token
-  """
-  decimals: BigInt
 }
 
 input ERC20_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
   address: Bytes
-  address_not: Bytes
-  address_gt: Bytes
-  address_lt: Bytes
-  address_gte: Bytes
-  address_lte: Bytes
-  address_in: [Bytes!]
-  address_not_in: [Bytes!]
   address_contains: Bytes
+  address_gt: Bytes
+  address_gte: Bytes
+  address_in: [Bytes!]
+  address_lt: Bytes
+  address_lte: Bytes
+  address_not: Bytes
   address_not_contains: Bytes
+  address_not_in: [Bytes!]
+  and: [ERC20_filter]
+  decimals: BigInt
+  decimals_gt: BigInt
+  decimals_gte: BigInt
+  decimals_in: [BigInt!]
+  decimals_lt: BigInt
+  decimals_lte: BigInt
+  decimals_not: BigInt
+  decimals_not_in: [BigInt!]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   name: String
-  name_not: String
-  name_gt: String
-  name_lt: String
-  name_gte: String
-  name_lte: String
-  name_in: [String!]
-  name_not_in: [String!]
   name_contains: String
   name_contains_nocase: String
-  name_not_contains: String
-  name_not_contains_nocase: String
-  name_starts_with: String
-  name_starts_with_nocase: String
-  name_not_starts_with: String
-  name_not_starts_with_nocase: String
   name_ends_with: String
   name_ends_with_nocase: String
+  name_gt: String
+  name_gte: String
+  name_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_not: String
+  name_not_contains: String
+  name_not_contains_nocase: String
   name_not_ends_with: String
   name_not_ends_with_nocase: String
+  name_not_in: [String!]
+  name_not_starts_with: String
+  name_not_starts_with_nocase: String
+  name_starts_with: String
+  name_starts_with_nocase: String
+  or: [ERC20_filter]
   symbol: String
-  symbol_not: String
-  symbol_gt: String
-  symbol_lt: String
-  symbol_gte: String
-  symbol_lte: String
-  symbol_in: [String!]
-  symbol_not_in: [String!]
   symbol_contains: String
   symbol_contains_nocase: String
-  symbol_not_contains: String
-  symbol_not_contains_nocase: String
-  symbol_starts_with: String
-  symbol_starts_with_nocase: String
-  symbol_not_starts_with: String
-  symbol_not_starts_with_nocase: String
   symbol_ends_with: String
   symbol_ends_with_nocase: String
+  symbol_gt: String
+  symbol_gte: String
+  symbol_in: [String!]
+  symbol_lt: String
+  symbol_lte: String
+  symbol_not: String
+  symbol_not_contains: String
+  symbol_not_contains_nocase: String
   symbol_not_ends_with: String
   symbol_not_ends_with_nocase: String
-  decimals: BigInt
-  decimals_not: BigInt
-  decimals_gt: BigInt
-  decimals_lt: BigInt
-  decimals_gte: BigInt
-  decimals_lte: BigInt
-  decimals_in: [BigInt!]
-  decimals_not_in: [BigInt!]
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [ERC20_filter]
-  or: [ERC20_filter]
+  symbol_not_in: [String!]
+  symbol_not_starts_with: String
+  symbol_not_starts_with_nocase: String
+  symbol_starts_with: String
+  symbol_starts_with_nocase: String
 }
 
 enum ERC20_orderBy {
-  id
   address
+  decimals
+  id
   name
   symbol
-  decimals
 }
 
 interface Event {
-  """
-  Transaction this event was emitted in
-  """
-  transaction: Transaction!
-
-  """
-  msg.sender for the event
-  """
+  """msg.sender for the event"""
   sender: Bytes!
+
+  """Transaction this event was emitted in"""
+  transaction: Transaction!
 }
 
 input Event_filter {
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Event_filter]
   or: [Event_filter]
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
 enum Event_orderBy {
+  sender
   transaction
-  transaction__id
-  transaction__timestamp
   transaction__blockNumber
   transaction__from
-  sender
+  transaction__id
+  transaction__timestamp
 }
 
 """
 8 bytes signed integer
+
 """
 scalar Int8
 
 type Order {
-  id: Bytes!
-
-  """
-  The raindex this order is in
-  """
-  raindex: Raindex!
-
-  """
-  Whether this order is active or not
-  """
+  """Whether this order is active or not"""
   active: Boolean!
 
-  """
-  The hash of the order
-  """
-  orderHash: Bytes!
-
-  """
-  The owner of the order
-  """
-  owner: Bytes!
-
-  """
-  The vaults that are inputs to this order
-  """
-  inputs(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Vault_orderBy
-    orderDirection: OrderDirection
-    where: Vault_filter
-  ): [Vault!]!
-
-  """
-  The vaults that are outputs to this order
-  """
-  outputs(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Vault_orderBy
-    orderDirection: OrderDirection
-    where: Vault_filter
-  ): [Vault!]!
-
-  """
-  A nonce for this order
-  """
-  nonce: Bytes!
-
-  """
-  The ABI encoded bytes for the Order struct
-  """
-  orderBytes: Bytes!
-
-  """
-  AddOrder events for this order
-  """
-  addEvents(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: AddOrder_orderBy
-    orderDirection: OrderDirection
-    where: AddOrder_filter
-  ): [AddOrder!]!
-
-  """
-  RemoveOrder events for this order
-  """
-  removeEvents(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: RemoveOrder_orderBy
-    orderDirection: OrderDirection
-    where: RemoveOrder_filter
-  ): [RemoveOrder!]!
-
-  """
-  Trades for this order
-  """
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-  ): [Trade!]!
-
-  """
-  Meta emitted for this order
-  """
-  meta: Bytes
-
-  """
-  The timestamp this order was first added
-  """
-  timestampAdded: BigInt!
-}
-
-input Order_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  active: Boolean
-  active_not: Boolean
-  active_in: [Boolean!]
-  active_not_in: [Boolean!]
-  orderHash: Bytes
-  orderHash_not: Bytes
-  orderHash_gt: Bytes
-  orderHash_lt: Bytes
-  orderHash_gte: Bytes
-  orderHash_lte: Bytes
-  orderHash_in: [Bytes!]
-  orderHash_not_in: [Bytes!]
-  orderHash_contains: Bytes
-  orderHash_not_contains: Bytes
-  owner: Bytes
-  owner_not: Bytes
-  owner_gt: Bytes
-  owner_lt: Bytes
-  owner_gte: Bytes
-  owner_lte: Bytes
-  owner_in: [Bytes!]
-  owner_not_in: [Bytes!]
-  owner_contains: Bytes
-  owner_not_contains: Bytes
-  inputs: [String!]
-  inputs_not: [String!]
-  inputs_contains: [String!]
-  inputs_contains_nocase: [String!]
-  inputs_not_contains: [String!]
-  inputs_not_contains_nocase: [String!]
-  inputs_: Vault_filter
-  outputs: [String!]
-  outputs_not: [String!]
-  outputs_contains: [String!]
-  outputs_contains_nocase: [String!]
-  outputs_not_contains: [String!]
-  outputs_not_contains_nocase: [String!]
-  outputs_: Vault_filter
-  nonce: Bytes
-  nonce_not: Bytes
-  nonce_gt: Bytes
-  nonce_lt: Bytes
-  nonce_gte: Bytes
-  nonce_lte: Bytes
-  nonce_in: [Bytes!]
-  nonce_not_in: [Bytes!]
-  nonce_contains: Bytes
-  nonce_not_contains: Bytes
-  orderBytes: Bytes
-  orderBytes_not: Bytes
-  orderBytes_gt: Bytes
-  orderBytes_lt: Bytes
-  orderBytes_gte: Bytes
-  orderBytes_lte: Bytes
-  orderBytes_in: [Bytes!]
-  orderBytes_not_in: [Bytes!]
-  orderBytes_contains: Bytes
-  orderBytes_not_contains: Bytes
-  addEvents_: AddOrder_filter
-  removeEvents_: RemoveOrder_filter
-  trades_: Trade_filter
-  meta: Bytes
-  meta_not: Bytes
-  meta_gt: Bytes
-  meta_lt: Bytes
-  meta_gte: Bytes
-  meta_lte: Bytes
-  meta_in: [Bytes!]
-  meta_not_in: [Bytes!]
-  meta_contains: Bytes
-  meta_not_contains: Bytes
-  timestampAdded: BigInt
-  timestampAdded_not: BigInt
-  timestampAdded_gt: BigInt
-  timestampAdded_lt: BigInt
-  timestampAdded_gte: BigInt
-  timestampAdded_lte: BigInt
-  timestampAdded_in: [BigInt!]
-  timestampAdded_not_in: [BigInt!]
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Order_filter]
-  or: [Order_filter]
-}
-
-enum Order_orderBy {
-  id
-  raindex
-  raindex__id
-  active
-  orderHash
-  owner
-  inputs
-  outputs
-  nonce
-  orderBytes
-  addEvents
-  removeEvents
-  trades
-  meta
-  timestampAdded
-}
-
-type Raindex {
+  """AddOrder events for this order"""
+  addEvents(first: Int = 100, orderBy: AddOrder_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: AddOrder_filter): [AddOrder!]!
   id: Bytes!
 
-  """
-  All orders in the raindex
-  """
-  orders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Order_orderBy
-    orderDirection: OrderDirection
-    where: Order_filter
-  ): [Order!]!
+  """The vaults that are inputs to this order"""
+  inputs(first: Int = 100, orderBy: Vault_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Vault_filter): [Vault!]!
 
-  """
-  All trades in the raindex
-  """
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-  ): [Trade!]!
+  """Meta emitted for this order"""
+  meta: Bytes
 
-  """
-  All vaults in the raindex
-  """
-  vaults(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Vault_orderBy
-    orderDirection: OrderDirection
-    where: Vault_filter
-  ): [Vault!]!
+  """A nonce for this order"""
+  nonce: Bytes!
 
-  """
-  All vault balance changes in the raindex
-  """
-  vaultBalanceChanges(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: VaultBalanceChange_orderBy
-    orderDirection: OrderDirection
-    where: VaultBalanceChange_filter
-  ): [VaultBalanceChange!]!
+  """The ABI encoded bytes for the Order struct"""
+  orderBytes: Bytes!
 
-  """
-  All deposit events in the raindex
-  """
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-  ): [Deposit!]!
+  """The hash of the order"""
+  orderHash: Bytes!
 
-  """
-  All withdrawal events in the raindex
-  """
-  withdrawals(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Withdrawal_orderBy
-    orderDirection: OrderDirection
-    where: Withdrawal_filter
-  ): [Withdrawal!]!
+  """The vaults that are outputs to this order"""
+  outputs(first: Int = 100, orderBy: Vault_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Vault_filter): [Vault!]!
 
-  """
-  All add order events in the raindex
-  """
-  addOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: AddOrder_orderBy
-    orderDirection: OrderDirection
-    where: AddOrder_filter
-  ): [AddOrder!]!
+  """The owner of the order"""
+  owner: Bytes!
 
-  """
-  All remove order events in the raindex
-  """
-  removeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: RemoveOrder_orderBy
-    orderDirection: OrderDirection
-    where: RemoveOrder_filter
-  ): [RemoveOrder!]!
+  """The raindex this order is in"""
+  raindex: Raindex!
 
-  """
-  All take order events in the raindex
-  """
-  takeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TakeOrder_orderBy
-    orderDirection: OrderDirection
-    where: TakeOrder_filter
-  ): [TakeOrder!]!
+  """RemoveOrder events for this order"""
+  removeEvents(first: Int = 100, orderBy: RemoveOrder_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: RemoveOrder_filter): [RemoveOrder!]!
 
-  """
-  All trade events in the raindex
-  """
-  tradeEvents(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TradeEvent_orderBy
-    orderDirection: OrderDirection
-    where: TradeEvent_filter
-  ): [TradeEvent!]!
+  """The timestamp this order was first added"""
+  timestampAdded: BigInt!
+
+  """Trades for this order"""
+  trades(first: Int = 100, orderBy: Trade_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Trade_filter): [Trade!]!
 }
 
-input Raindex_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  orders_: Order_filter
-  trades_: Trade_filter
-  vaults_: Vault_filter
-  vaultBalanceChanges_: VaultBalanceChange_filter
-  deposits_: Deposit_filter
-  withdrawals_: Withdrawal_filter
-  addOrders_: AddOrder_filter
-  removeOrders_: RemoveOrder_filter
-  takeOrders_: TakeOrder_filter
-  tradeEvents_: TradeEvent_filter
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Raindex_filter]
-  or: [Raindex_filter]
-}
-
-enum Raindex_orderBy {
-  id
-  orders
-  trades
-  vaults
-  vaultBalanceChanges
-  deposits
-  withdrawals
-  addOrders
-  removeOrders
-  takeOrders
-  tradeEvents
-}
-
-"""
-Defines the order direction, either ascending or descending
-"""
+"""Defines the order direction, either ascending or descending"""
 enum OrderDirection {
   asc
   desc
 }
 
+input Order_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  active: Boolean
+  active_in: [Boolean!]
+  active_not: Boolean
+  active_not_in: [Boolean!]
+  addEvents_: AddOrder_filter
+  and: [Order_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  inputs: [String!]
+  inputs_: Vault_filter
+  inputs_contains: [String!]
+  inputs_contains_nocase: [String!]
+  inputs_not: [String!]
+  inputs_not_contains: [String!]
+  inputs_not_contains_nocase: [String!]
+  meta: Bytes
+  meta_contains: Bytes
+  meta_gt: Bytes
+  meta_gte: Bytes
+  meta_in: [Bytes!]
+  meta_lt: Bytes
+  meta_lte: Bytes
+  meta_not: Bytes
+  meta_not_contains: Bytes
+  meta_not_in: [Bytes!]
+  nonce: Bytes
+  nonce_contains: Bytes
+  nonce_gt: Bytes
+  nonce_gte: Bytes
+  nonce_in: [Bytes!]
+  nonce_lt: Bytes
+  nonce_lte: Bytes
+  nonce_not: Bytes
+  nonce_not_contains: Bytes
+  nonce_not_in: [Bytes!]
+  or: [Order_filter]
+  orderBytes: Bytes
+  orderBytes_contains: Bytes
+  orderBytes_gt: Bytes
+  orderBytes_gte: Bytes
+  orderBytes_in: [Bytes!]
+  orderBytes_lt: Bytes
+  orderBytes_lte: Bytes
+  orderBytes_not: Bytes
+  orderBytes_not_contains: Bytes
+  orderBytes_not_in: [Bytes!]
+  orderHash: Bytes
+  orderHash_contains: Bytes
+  orderHash_gt: Bytes
+  orderHash_gte: Bytes
+  orderHash_in: [Bytes!]
+  orderHash_lt: Bytes
+  orderHash_lte: Bytes
+  orderHash_not: Bytes
+  orderHash_not_contains: Bytes
+  orderHash_not_in: [Bytes!]
+  outputs: [String!]
+  outputs_: Vault_filter
+  outputs_contains: [String!]
+  outputs_contains_nocase: [String!]
+  outputs_not: [String!]
+  outputs_not_contains: [String!]
+  outputs_not_contains_nocase: [String!]
+  owner: Bytes
+  owner_contains: Bytes
+  owner_gt: Bytes
+  owner_gte: Bytes
+  owner_in: [Bytes!]
+  owner_lt: Bytes
+  owner_lte: Bytes
+  owner_not: Bytes
+  owner_not_contains: Bytes
+  owner_not_in: [Bytes!]
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  removeEvents_: RemoveOrder_filter
+  timestampAdded: BigInt
+  timestampAdded_gt: BigInt
+  timestampAdded_gte: BigInt
+  timestampAdded_in: [BigInt!]
+  timestampAdded_lt: BigInt
+  timestampAdded_lte: BigInt
+  timestampAdded_not: BigInt
+  timestampAdded_not_in: [BigInt!]
+  trades_: Trade_filter
+}
+
+enum Order_orderBy {
+  active
+  addEvents
+  id
+  inputs
+  meta
+  nonce
+  orderBytes
+  orderHash
+  outputs
+  owner
+  raindex
+  raindex__id
+  removeEvents
+  timestampAdded
+  trades
+}
+
 type Query {
-  raindex(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Raindex
-  raindexs(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Raindex_orderBy
-    orderDirection: OrderDirection
-    where: Raindex_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Raindex!]!
-  vault(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Vault
-  vaults(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Vault_orderBy
-    orderDirection: OrderDirection
-    where: Vault_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Vault!]!
-  deposit(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
-  withdrawal(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Withdrawal
-  withdrawals(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Withdrawal_orderBy
-    orderDirection: OrderDirection
-    where: Withdrawal_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Withdrawal!]!
-  tradeVaultBalanceChange(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TradeVaultBalanceChange
-  tradeVaultBalanceChanges(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TradeVaultBalanceChange_orderBy
-    orderDirection: OrderDirection
-    where: TradeVaultBalanceChange_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TradeVaultBalanceChange!]!
-  clearBounty(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): ClearBounty
-  clearBounties(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: ClearBounty_orderBy
-    orderDirection: OrderDirection
-    where: ClearBounty_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [ClearBounty!]!
-  order(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Order
-  orders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Order_orderBy
-    orderDirection: OrderDirection
-    where: Order_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Order!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
   addOrder(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -1948,279 +1292,67 @@ type Query {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): AddOrder
   addOrders(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: AddOrder_orderBy
     orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
     where: AddOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [AddOrder!]!
-  removeOrder(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): RemoveOrder
-  removeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: RemoveOrder_orderBy
-    orderDirection: OrderDirection
-    where: RemoveOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [RemoveOrder!]!
-  trade(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Trade
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Trade!]!
-  takeOrder(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TakeOrder
-  takeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TakeOrder_orderBy
-    orderDirection: OrderDirection
-    where: TakeOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TakeOrder!]!
   clear(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): Clear
-  clears(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Clear_orderBy
-    orderDirection: OrderDirection
-    where: Clear_filter
-
+  clearBounties(
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    first: Int = 100
+    orderBy: ClearBounty_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Clear!]!
-  transaction(
+    where: ClearBounty_filter
+  ): [ClearBounty!]!
+  clearBounty(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Transaction
-  transactions(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Transaction_orderBy
-    orderDirection: OrderDirection
-    where: Transaction_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Transaction!]!
-  erc20(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): ERC20
-  erc20S(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: ERC20_orderBy
-    orderDirection: OrderDirection
-    where: ERC20_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [ERC20!]!
+  ): ClearBounty
   clearTemporaryData(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -2228,119 +1360,99 @@ type Query {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): ClearTemporaryData
   clearTemporaryDatas(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: ClearTemporaryData_orderBy
     orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
     where: ClearTemporaryData_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [ClearTemporaryData!]!
-  vaultBalanceChange(
+  clears(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Clear_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Clear_filter
+  ): [Clear!]!
+  deposit(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): VaultBalanceChange
-  vaultBalanceChanges(
-    skip: Int = 0
+  ): Deposit
+  deposits(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
-    orderBy: VaultBalanceChange_orderBy
+    orderBy: Deposit_orderBy
     orderDirection: OrderDirection
-    where: VaultBalanceChange_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [VaultBalanceChange!]!
-  tradeEvent(
+    where: Deposit_filter
+  ): [Deposit!]!
+  erc20(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TradeEvent
-  tradeEvents(
-    skip: Int = 0
+  ): ERC20
+  erc20S(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
-    orderBy: TradeEvent_orderBy
+    orderBy: ERC20_orderBy
     orderDirection: OrderDirection
-    where: TradeEvent_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TradeEvent!]!
+    where: ERC20_filter
+  ): [ERC20!]!
   event(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -2348,461 +1460,539 @@ type Query {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): Event
   events(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: Event_orderBy
     orderDirection: OrderDirection
-    where: Event_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Event_filter
   ): [Event!]!
+  order(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
 
-  """
-  Access to subgraph metadata
-  """
-  _meta(block: Block_height): _Meta_
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Order
+  orders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Order_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Order_filter
+  ): [Order!]!
+  raindex(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Raindex
+  raindices(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Raindex_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Raindex_filter
+  ): [Raindex!]!
+  removeOrder(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RemoveOrder
+  removeOrders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: RemoveOrder_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: RemoveOrder_filter
+  ): [RemoveOrder!]!
+  takeOrder(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TakeOrder
+  takeOrders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TakeOrder_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TakeOrder_filter
+  ): [TakeOrder!]!
+  trade(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Trade
+  tradeEvent(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TradeEvent
+  tradeEvents(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TradeEvent_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TradeEvent_filter
+  ): [TradeEvent!]!
+  tradeVaultBalanceChange(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TradeVaultBalanceChange
+  tradeVaultBalanceChanges(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TradeVaultBalanceChange_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TradeVaultBalanceChange_filter
+  ): [TradeVaultBalanceChange!]!
+  trades(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Trade_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Trade_filter
+  ): [Trade!]!
+  transaction(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transaction
+  transactions(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Transaction_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Transaction_filter
+  ): [Transaction!]!
+  vault(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Vault
+  vaultBalanceChange(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VaultBalanceChange
+  vaultBalanceChanges(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: VaultBalanceChange_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: VaultBalanceChange_filter
+  ): [VaultBalanceChange!]!
+  vaults(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Vault_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Vault_filter
+  ): [Vault!]!
+  withdrawal(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Withdrawal
+  withdrawals(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Withdrawal_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Withdrawal_filter
+  ): [Withdrawal!]!
+}
+
+type Raindex {
+  """All add order events in the raindex"""
+  addOrders(first: Int = 100, orderBy: AddOrder_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: AddOrder_filter): [AddOrder!]!
+
+  """All deposit events in the raindex"""
+  deposits(first: Int = 100, orderBy: Deposit_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Deposit_filter): [Deposit!]!
+  id: Bytes!
+
+  """All orders in the raindex"""
+  orders(first: Int = 100, orderBy: Order_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Order_filter): [Order!]!
+
+  """All remove order events in the raindex"""
+  removeOrders(first: Int = 100, orderBy: RemoveOrder_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: RemoveOrder_filter): [RemoveOrder!]!
+
+  """All take order events in the raindex"""
+  takeOrders(first: Int = 100, orderBy: TakeOrder_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: TakeOrder_filter): [TakeOrder!]!
+
+  """All trade events in the raindex"""
+  tradeEvents(first: Int = 100, orderBy: TradeEvent_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: TradeEvent_filter): [TradeEvent!]!
+
+  """All trades in the raindex"""
+  trades(first: Int = 100, orderBy: Trade_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Trade_filter): [Trade!]!
+
+  """All vault balance changes in the raindex"""
+  vaultBalanceChanges(first: Int = 100, orderBy: VaultBalanceChange_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: VaultBalanceChange_filter): [VaultBalanceChange!]!
+
+  """All vaults in the raindex"""
+  vaults(first: Int = 100, orderBy: Vault_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Vault_filter): [Vault!]!
+
+  """All withdrawal events in the raindex"""
+  withdrawals(first: Int = 100, orderBy: Withdrawal_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Withdrawal_filter): [Withdrawal!]!
+}
+
+input Raindex_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  addOrders_: AddOrder_filter
+  and: [Raindex_filter]
+  deposits_: Deposit_filter
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  or: [Raindex_filter]
+  orders_: Order_filter
+  removeOrders_: RemoveOrder_filter
+  takeOrders_: TakeOrder_filter
+  tradeEvents_: TradeEvent_filter
+  trades_: Trade_filter
+  vaultBalanceChanges_: VaultBalanceChange_filter
+  vaults_: Vault_filter
+  withdrawals_: Withdrawal_filter
+}
+
+enum Raindex_orderBy {
+  addOrders
+  deposits
+  id
+  orders
+  removeOrders
+  takeOrders
+  tradeEvents
+  trades
+  vaultBalanceChanges
+  vaults
+  withdrawals
 }
 
 type RemoveOrder implements Event {
   id: Bytes!
 
-  """
-  The order that was removed
-  """
+  """The order that was removed"""
   order: Order!
 
-  """
-  The raindex this remove order event is in
-  """
+  """The raindex this remove order event is in"""
   raindex: Raindex!
-  transaction: Transaction!
 
-  """
-  The msg.sender of this remove order call
-  """
+  """The msg.sender of this remove order call"""
   sender: Bytes!
+  transaction: Transaction!
 }
 
 input RemoveOrder_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  order: String
-  order_not: String
-  order_gt: String
-  order_lt: String
-  order_gte: String
-  order_lte: String
-  order_in: [String!]
-  order_not_in: [String!]
-  order_contains: String
-  order_contains_nocase: String
-  order_not_contains: String
-  order_not_contains_nocase: String
-  order_starts_with: String
-  order_starts_with_nocase: String
-  order_not_starts_with: String
-  order_not_starts_with_nocase: String
-  order_ends_with: String
-  order_ends_with_nocase: String
-  order_not_ends_with: String
-  order_not_ends_with_nocase: String
-  order_: Order_filter
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [RemoveOrder_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   or: [RemoveOrder_filter]
+  order: String
+  order_: Order_filter
+  order_contains: String
+  order_contains_nocase: String
+  order_ends_with: String
+  order_ends_with_nocase: String
+  order_gt: String
+  order_gte: String
+  order_in: [String!]
+  order_lt: String
+  order_lte: String
+  order_not: String
+  order_not_contains: String
+  order_not_contains_nocase: String
+  order_not_ends_with: String
+  order_not_ends_with_nocase: String
+  order_not_in: [String!]
+  order_not_starts_with: String
+  order_not_starts_with_nocase: String
+  order_starts_with: String
+  order_starts_with_nocase: String
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
 enum RemoveOrder_orderBy {
   id
   order
-  order__id
   order__active
-  order__orderHash
-  order__owner
+  order__id
+  order__meta
   order__nonce
   order__orderBytes
-  order__meta
+  order__orderHash
+  order__owner
   order__timestampAdded
   raindex
   raindex__id
+  sender
   transaction
-  transaction__id
-  transaction__timestamp
   transaction__blockNumber
   transaction__from
-  sender
+  transaction__id
+  transaction__timestamp
 }
 
 type Subscription {
-  raindex(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Raindex
-  raindexs(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Raindex_orderBy
-    orderDirection: OrderDirection
-    where: Raindex_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Raindex!]!
-  vault(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Vault
-  vaults(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Vault_orderBy
-    orderDirection: OrderDirection
-    where: Vault_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Vault!]!
-  deposit(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Deposit
-  deposits(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Deposit_orderBy
-    orderDirection: OrderDirection
-    where: Deposit_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Deposit!]!
-  withdrawal(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Withdrawal
-  withdrawals(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Withdrawal_orderBy
-    orderDirection: OrderDirection
-    where: Withdrawal_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Withdrawal!]!
-  tradeVaultBalanceChange(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TradeVaultBalanceChange
-  tradeVaultBalanceChanges(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TradeVaultBalanceChange_orderBy
-    orderDirection: OrderDirection
-    where: TradeVaultBalanceChange_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TradeVaultBalanceChange!]!
-  clearBounty(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): ClearBounty
-  clearBounties(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: ClearBounty_orderBy
-    orderDirection: OrderDirection
-    where: ClearBounty_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [ClearBounty!]!
-  order(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Order
-  orders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Order_orderBy
-    orderDirection: OrderDirection
-    where: Order_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Order!]!
+  """Access to subgraph metadata"""
+  _meta(block: Block_height): _Meta_
   addOrder(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -2810,279 +2000,67 @@ type Subscription {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): AddOrder
   addOrders(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: AddOrder_orderBy
     orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
     where: AddOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [AddOrder!]!
-  removeOrder(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): RemoveOrder
-  removeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: RemoveOrder_orderBy
-    orderDirection: OrderDirection
-    where: RemoveOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [RemoveOrder!]!
-  trade(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Trade
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Trade!]!
-  takeOrder(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TakeOrder
-  takeOrders(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: TakeOrder_orderBy
-    orderDirection: OrderDirection
-    where: TakeOrder_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TakeOrder!]!
   clear(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): Clear
-  clears(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Clear_orderBy
-    orderDirection: OrderDirection
-    where: Clear_filter
-
+  clearBounties(
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    first: Int = 100
+    orderBy: ClearBounty_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Clear!]!
-  transaction(
+    where: ClearBounty_filter
+  ): [ClearBounty!]!
+  clearBounty(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): Transaction
-  transactions(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Transaction_orderBy
-    orderDirection: OrderDirection
-    where: Transaction_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [Transaction!]!
-  erc20(
-    id: ID!
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): ERC20
-  erc20S(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: ERC20_orderBy
-    orderDirection: OrderDirection
-    where: ERC20_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [ERC20!]!
+  ): ClearBounty
   clearTemporaryData(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -3090,119 +2068,99 @@ type Subscription {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): ClearTemporaryData
   clearTemporaryDatas(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: ClearTemporaryData_orderBy
     orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
     where: ClearTemporaryData_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
-    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
-    """
-    subgraphError: _SubgraphErrorPolicy_! = deny
   ): [ClearTemporaryData!]!
-  vaultBalanceChange(
+  clears(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Clear_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Clear_filter
+  ): [Clear!]!
+  deposit(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): VaultBalanceChange
-  vaultBalanceChanges(
-    skip: Int = 0
+  ): Deposit
+  deposits(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
-    orderBy: VaultBalanceChange_orderBy
+    orderBy: Deposit_orderBy
     orderDirection: OrderDirection
-    where: VaultBalanceChange_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [VaultBalanceChange!]!
-  tradeEvent(
+    where: Deposit_filter
+  ): [Deposit!]!
+  erc20(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     id: ID!
 
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
-
-    """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): TradeEvent
-  tradeEvents(
-    skip: Int = 0
+  ): ERC20
+  erc20S(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
-    orderBy: TradeEvent_orderBy
+    orderBy: ERC20_orderBy
     orderDirection: OrderDirection
-    where: TradeEvent_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
-  ): [TradeEvent!]!
+    where: ERC20_filter
+  ): [ERC20!]!
   event(
-    id: ID!
-
     """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
     """
     block: Block_height
+    id: ID!
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
@@ -3210,1325 +2168,1514 @@ type Subscription {
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): Event
   events(
-    skip: Int = 0
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: Event_orderBy
     orderDirection: OrderDirection
-    where: Event_filter
-
-    """
-    The block at which the query should be executed. Can either be a `{ hash:
-    Bytes }` value containing a block hash, a `{ number: Int }` containing the
-    block number, or a `{ number_gte: Int }` containing the minimum block
-    number. In the case of `number_gte`, the query will be executed on the
-    latest block only if the subgraph has progressed to or past the minimum
-    block number. Defaults to the latest block when omitted.
-    """
-    block: Block_height
+    skip: Int = 0
 
     """
     Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Event_filter
   ): [Event!]!
+  order(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
 
-  """
-  Access to subgraph metadata
-  """
-  _meta(block: Block_height): _Meta_
-}
-
-type TakeOrder implements TradeEvent {
-  id: Bytes!
-
-  """
-  The input amount from the perspective of the taker
-  """
-  inputAmount: Bytes!
-
-  """
-  The output amount from the perspective of the taker
-  """
-  outputAmount: Bytes!
-
-  """
-  The ABI encoded bytes for the TakeOrderConfig struct
-  """
-  takeOrderConfigBytes: Bytes!
-
-  """
-  The raindex this trade event is for
-  """
-  raindex: Raindex!
-
-  """
-  The trades that occured in this event
-  """
-  trades(
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Order
+  orders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Order_orderBy
+    orderDirection: OrderDirection
     skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Order_filter
+  ): [Order!]!
+  raindex(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Raindex
+  raindices(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Raindex_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Raindex_filter
+  ): [Raindex!]!
+  removeOrder(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RemoveOrder
+  removeOrders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: RemoveOrder_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: RemoveOrder_filter
+  ): [RemoveOrder!]!
+  takeOrder(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TakeOrder
+  takeOrders(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TakeOrder_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TakeOrder_filter
+  ): [TakeOrder!]!
+  trade(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Trade
+  tradeEvent(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TradeEvent
+  tradeEvents(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TradeEvent_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TradeEvent_filter
+  ): [TradeEvent!]!
+  tradeVaultBalanceChange(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): TradeVaultBalanceChange
+  tradeVaultBalanceChanges(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: TradeVaultBalanceChange_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: TradeVaultBalanceChange_filter
+  ): [TradeVaultBalanceChange!]!
+  trades(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
     first: Int = 100
     orderBy: Trade_orderBy
     orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
     where: Trade_filter
   ): [Trade!]!
-  transaction: Transaction!
+  transaction(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
 
-  """
-  The msg.sender of this trade
-  """
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Transaction
+  transactions(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Transaction_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Transaction_filter
+  ): [Transaction!]!
+  vault(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Vault
+  vaultBalanceChange(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): VaultBalanceChange
+  vaultBalanceChanges(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: VaultBalanceChange_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: VaultBalanceChange_filter
+  ): [VaultBalanceChange!]!
+  vaults(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Vault_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Vault_filter
+  ): [Vault!]!
+  withdrawal(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    id: ID!
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Withdrawal
+  withdrawals(
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    first: Int = 100
+    orderBy: Withdrawal_orderBy
+    orderDirection: OrderDirection
+    skip: Int = 0
+
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+    where: Withdrawal_filter
+  ): [Withdrawal!]!
+}
+
+type TakeOrder implements Event & TradeEvent {
+  id: Bytes!
+
+  """The input amount from the perspective of the taker"""
+  inputAmount: Bytes!
+
+  """The output amount from the perspective of the taker"""
+  outputAmount: Bytes!
+
+  """The raindex this trade event is for"""
+  raindex: Raindex!
+
+  """The msg.sender of this trade"""
   sender: Bytes!
+
+  """The ABI encoded bytes for the TakeOrderConfig struct"""
+  takeOrderConfigBytes: Bytes!
+
+  """The trades that occured in this event"""
+  trades(first: Int = 100, orderBy: Trade_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Trade_filter): [Trade!]!
+  transaction: Transaction!
 }
 
 input TakeOrder_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  inputAmount: Bytes
-  inputAmount_not: Bytes
-  inputAmount_gt: Bytes
-  inputAmount_lt: Bytes
-  inputAmount_gte: Bytes
-  inputAmount_lte: Bytes
-  inputAmount_in: [Bytes!]
-  inputAmount_not_in: [Bytes!]
-  inputAmount_contains: Bytes
-  inputAmount_not_contains: Bytes
-  outputAmount: Bytes
-  outputAmount_not: Bytes
-  outputAmount_gt: Bytes
-  outputAmount_lt: Bytes
-  outputAmount_gte: Bytes
-  outputAmount_lte: Bytes
-  outputAmount_in: [Bytes!]
-  outputAmount_not_in: [Bytes!]
-  outputAmount_contains: Bytes
-  outputAmount_not_contains: Bytes
-  takeOrderConfigBytes: Bytes
-  takeOrderConfigBytes_not: Bytes
-  takeOrderConfigBytes_gt: Bytes
-  takeOrderConfigBytes_lt: Bytes
-  takeOrderConfigBytes_gte: Bytes
-  takeOrderConfigBytes_lte: Bytes
-  takeOrderConfigBytes_in: [Bytes!]
-  takeOrderConfigBytes_not_in: [Bytes!]
-  takeOrderConfigBytes_contains: Bytes
-  takeOrderConfigBytes_not_contains: Bytes
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  trades_: Trade_filter
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [TakeOrder_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  inputAmount: Bytes
+  inputAmount_contains: Bytes
+  inputAmount_gt: Bytes
+  inputAmount_gte: Bytes
+  inputAmount_in: [Bytes!]
+  inputAmount_lt: Bytes
+  inputAmount_lte: Bytes
+  inputAmount_not: Bytes
+  inputAmount_not_contains: Bytes
+  inputAmount_not_in: [Bytes!]
   or: [TakeOrder_filter]
+  outputAmount: Bytes
+  outputAmount_contains: Bytes
+  outputAmount_gt: Bytes
+  outputAmount_gte: Bytes
+  outputAmount_in: [Bytes!]
+  outputAmount_lt: Bytes
+  outputAmount_lte: Bytes
+  outputAmount_not: Bytes
+  outputAmount_not_contains: Bytes
+  outputAmount_not_in: [Bytes!]
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  takeOrderConfigBytes: Bytes
+  takeOrderConfigBytes_contains: Bytes
+  takeOrderConfigBytes_gt: Bytes
+  takeOrderConfigBytes_gte: Bytes
+  takeOrderConfigBytes_in: [Bytes!]
+  takeOrderConfigBytes_lt: Bytes
+  takeOrderConfigBytes_lte: Bytes
+  takeOrderConfigBytes_not: Bytes
+  takeOrderConfigBytes_not_contains: Bytes
+  takeOrderConfigBytes_not_in: [Bytes!]
+  trades_: Trade_filter
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
 enum TakeOrder_orderBy {
   id
   inputAmount
   outputAmount
-  takeOrderConfigBytes
   raindex
   raindex__id
+  sender
+  takeOrderConfigBytes
   trades
   transaction
-  transaction__id
-  transaction__timestamp
   transaction__blockNumber
   transaction__from
-  sender
+  transaction__id
+  transaction__timestamp
 }
 
 """
 A string representation of microseconds UNIX timestamp (16 digits)
+
 """
 scalar Timestamp
 
 type Trade {
   id: Bytes!
 
-  """
-  The raindex this trade is for
-  """
-  raindex: Raindex!
-
-  """
-  The order that was traded
-  """
-  order: Order!
-
-  """
-  Input vault balance change
-  """
+  """Input vault balance change"""
   inputVaultBalanceChange: TradeVaultBalanceChange!
 
-  """
-  Output vault balance change
-  """
+  """The order that was traded"""
+  order: Order!
+
+  """Output vault balance change"""
   outputVaultBalanceChange: TradeVaultBalanceChange!
 
-  """
-  The event in which this trade occured
-  """
-  tradeEvent: TradeEvent!
+  """The raindex this trade is for"""
+  raindex: Raindex!
 
-  """
-  The timestamp this trade was executed
-  """
+  """The timestamp this trade was executed"""
   timestamp: BigInt!
-}
 
-input Trade_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  order: String
-  order_not: String
-  order_gt: String
-  order_lt: String
-  order_gte: String
-  order_lte: String
-  order_in: [String!]
-  order_not_in: [String!]
-  order_contains: String
-  order_contains_nocase: String
-  order_not_contains: String
-  order_not_contains_nocase: String
-  order_starts_with: String
-  order_starts_with_nocase: String
-  order_not_starts_with: String
-  order_not_starts_with_nocase: String
-  order_ends_with: String
-  order_ends_with_nocase: String
-  order_not_ends_with: String
-  order_not_ends_with_nocase: String
-  order_: Order_filter
-  inputVaultBalanceChange: String
-  inputVaultBalanceChange_not: String
-  inputVaultBalanceChange_gt: String
-  inputVaultBalanceChange_lt: String
-  inputVaultBalanceChange_gte: String
-  inputVaultBalanceChange_lte: String
-  inputVaultBalanceChange_in: [String!]
-  inputVaultBalanceChange_not_in: [String!]
-  inputVaultBalanceChange_contains: String
-  inputVaultBalanceChange_contains_nocase: String
-  inputVaultBalanceChange_not_contains: String
-  inputVaultBalanceChange_not_contains_nocase: String
-  inputVaultBalanceChange_starts_with: String
-  inputVaultBalanceChange_starts_with_nocase: String
-  inputVaultBalanceChange_not_starts_with: String
-  inputVaultBalanceChange_not_starts_with_nocase: String
-  inputVaultBalanceChange_ends_with: String
-  inputVaultBalanceChange_ends_with_nocase: String
-  inputVaultBalanceChange_not_ends_with: String
-  inputVaultBalanceChange_not_ends_with_nocase: String
-  inputVaultBalanceChange_: TradeVaultBalanceChange_filter
-  outputVaultBalanceChange: String
-  outputVaultBalanceChange_not: String
-  outputVaultBalanceChange_gt: String
-  outputVaultBalanceChange_lt: String
-  outputVaultBalanceChange_gte: String
-  outputVaultBalanceChange_lte: String
-  outputVaultBalanceChange_in: [String!]
-  outputVaultBalanceChange_not_in: [String!]
-  outputVaultBalanceChange_contains: String
-  outputVaultBalanceChange_contains_nocase: String
-  outputVaultBalanceChange_not_contains: String
-  outputVaultBalanceChange_not_contains_nocase: String
-  outputVaultBalanceChange_starts_with: String
-  outputVaultBalanceChange_starts_with_nocase: String
-  outputVaultBalanceChange_not_starts_with: String
-  outputVaultBalanceChange_not_starts_with_nocase: String
-  outputVaultBalanceChange_ends_with: String
-  outputVaultBalanceChange_ends_with_nocase: String
-  outputVaultBalanceChange_not_ends_with: String
-  outputVaultBalanceChange_not_ends_with_nocase: String
-  outputVaultBalanceChange_: TradeVaultBalanceChange_filter
-  tradeEvent: String
-  tradeEvent_not: String
-  tradeEvent_gt: String
-  tradeEvent_lt: String
-  tradeEvent_gte: String
-  tradeEvent_lte: String
-  tradeEvent_in: [String!]
-  tradeEvent_not_in: [String!]
-  tradeEvent_contains: String
-  tradeEvent_contains_nocase: String
-  tradeEvent_not_contains: String
-  tradeEvent_not_contains_nocase: String
-  tradeEvent_starts_with: String
-  tradeEvent_starts_with_nocase: String
-  tradeEvent_not_starts_with: String
-  tradeEvent_not_starts_with_nocase: String
-  tradeEvent_ends_with: String
-  tradeEvent_ends_with_nocase: String
-  tradeEvent_not_ends_with: String
-  tradeEvent_not_ends_with_nocase: String
-  tradeEvent_: TradeEvent_filter
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Trade_filter]
-  or: [Trade_filter]
-}
-
-enum Trade_orderBy {
-  id
-  raindex
-  raindex__id
-  order
-  order__id
-  order__active
-  order__orderHash
-  order__owner
-  order__nonce
-  order__orderBytes
-  order__meta
-  order__timestampAdded
-  inputVaultBalanceChange
-  inputVaultBalanceChange__id
-  inputVaultBalanceChange__amount
-  inputVaultBalanceChange__oldVaultBalance
-  inputVaultBalanceChange__newVaultBalance
-  inputVaultBalanceChange__timestamp
-  outputVaultBalanceChange
-  outputVaultBalanceChange__id
-  outputVaultBalanceChange__amount
-  outputVaultBalanceChange__oldVaultBalance
-  outputVaultBalanceChange__newVaultBalance
-  outputVaultBalanceChange__timestamp
-  tradeEvent
-  tradeEvent__id
-  tradeEvent__sender
-  timestamp
+  """The event in which this trade occured"""
+  tradeEvent: TradeEvent!
 }
 
 interface TradeEvent {
   id: Bytes!
 
-  """
-  The raindex this trade event is for
-  """
+  """The raindex this trade event is for"""
   raindex: Raindex!
 
-  """
-  The trades that occured in this event
-  """
-  trades(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Trade_orderBy
-    orderDirection: OrderDirection
-    where: Trade_filter
-  ): [Trade!]!
-  transaction: Transaction!
-
-  """
-  The msg.sender of this trade
-  """
+  """The msg.sender of this trade"""
   sender: Bytes!
+
+  """The trades that occured in this event"""
+  trades(first: Int = 100, orderBy: Trade_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Trade_filter): [Trade!]!
+  transaction: Transaction!
 }
 
 input TradeEvent_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  trades_: Trade_filter
-  transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
-  transaction_contains: String
-  transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
-  transaction_ends_with: String
-  transaction_ends_with_nocase: String
-  transaction_not_ends_with: String
-  transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [TradeEvent_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   or: [TradeEvent_filter]
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  trades_: Trade_filter
+  transaction: String
+  transaction_: Transaction_filter
+  transaction_contains: String
+  transaction_contains_nocase: String
+  transaction_ends_with: String
+  transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
+  transaction_not_ends_with: String
+  transaction_not_ends_with_nocase: String
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
 }
 
 enum TradeEvent_orderBy {
   id
   raindex
   raindex__id
+  sender
   trades
   transaction
-  transaction__id
-  transaction__timestamp
   transaction__blockNumber
   transaction__from
-  sender
+  transaction__id
+  transaction__timestamp
 }
 
 type TradeVaultBalanceChange implements VaultBalanceChange {
+  """The amount that was changed - this is signed"""
+  amount: Bytes!
   id: Bytes!
 
-  """
-  The raindex this balance change is for
-  """
-  raindex: Raindex!
-
-  """
-  The trade that this balance change is for
-  """
-  trade: Trade!
-
-  """
-  The vault that was affected
-  """
-  vault: Vault!
-
-  """
-  The amount that was changed - this is signed
-  """
-  amount: Bytes!
-
-  """
-  The balance of the vault before the change
-  """
-  oldVaultBalance: Bytes!
-
-  """
-  The balance of the vault after the change
-  """
+  """The balance of the vault after the change"""
   newVaultBalance: Bytes!
 
-  """
-  The timestamp this balance change was executed
-  """
+  """The balance of the vault before the change"""
+  oldVaultBalance: Bytes!
+
+  """The raindex this balance change is for"""
+  raindex: Raindex!
+
+  """The timestamp this balance change was executed"""
   timestamp: BigInt!
 
-  """
-  The transaction in which this balance change was executed
-  """
+  """The trade that this balance change is for"""
+  trade: Trade!
+
+  """The transaction in which this balance change was executed"""
   transaction: Transaction!
+
+  """The vault that was affected"""
+  vault: Vault!
 }
 
 input TradeVaultBalanceChange_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  amount: Bytes
+  amount_contains: Bytes
+  amount_gt: Bytes
+  amount_gte: Bytes
+  amount_in: [Bytes!]
+  amount_lt: Bytes
+  amount_lte: Bytes
+  amount_not: Bytes
+  amount_not_contains: Bytes
+  amount_not_in: [Bytes!]
+  and: [TradeVaultBalanceChange_filter]
   id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
   id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
   id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  newVaultBalance: Bytes
+  newVaultBalance_contains: Bytes
+  newVaultBalance_gt: Bytes
+  newVaultBalance_gte: Bytes
+  newVaultBalance_in: [Bytes!]
+  newVaultBalance_lt: Bytes
+  newVaultBalance_lte: Bytes
+  newVaultBalance_not: Bytes
+  newVaultBalance_not_contains: Bytes
+  newVaultBalance_not_in: [Bytes!]
+  oldVaultBalance: Bytes
+  oldVaultBalance_contains: Bytes
+  oldVaultBalance_gt: Bytes
+  oldVaultBalance_gte: Bytes
+  oldVaultBalance_in: [Bytes!]
+  oldVaultBalance_lt: Bytes
+  oldVaultBalance_lte: Bytes
+  oldVaultBalance_not: Bytes
+  oldVaultBalance_not_contains: Bytes
+  oldVaultBalance_not_in: [Bytes!]
+  or: [TradeVaultBalanceChange_filter]
   raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
+  raindex_: Raindex_filter
   raindex_contains: String
   raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
   raindex_ends_with: String
   raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
   raindex_not_ends_with: String
   raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  timestamp: BigInt
+  timestamp_gt: BigInt
+  timestamp_gte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
+  timestamp_not_in: [BigInt!]
   trade: String
-  trade_not: String
-  trade_gt: String
-  trade_lt: String
-  trade_gte: String
-  trade_lte: String
-  trade_in: [String!]
-  trade_not_in: [String!]
+  trade_: Trade_filter
   trade_contains: String
   trade_contains_nocase: String
-  trade_not_contains: String
-  trade_not_contains_nocase: String
-  trade_starts_with: String
-  trade_starts_with_nocase: String
-  trade_not_starts_with: String
-  trade_not_starts_with_nocase: String
   trade_ends_with: String
   trade_ends_with_nocase: String
+  trade_gt: String
+  trade_gte: String
+  trade_in: [String!]
+  trade_lt: String
+  trade_lte: String
+  trade_not: String
+  trade_not_contains: String
+  trade_not_contains_nocase: String
   trade_not_ends_with: String
   trade_not_ends_with_nocase: String
-  trade_: Trade_filter
-  vault: String
-  vault_not: String
-  vault_gt: String
-  vault_lt: String
-  vault_gte: String
-  vault_lte: String
-  vault_in: [String!]
-  vault_not_in: [String!]
-  vault_contains: String
-  vault_contains_nocase: String
-  vault_not_contains: String
-  vault_not_contains_nocase: String
-  vault_starts_with: String
-  vault_starts_with_nocase: String
-  vault_not_starts_with: String
-  vault_not_starts_with_nocase: String
-  vault_ends_with: String
-  vault_ends_with_nocase: String
-  vault_not_ends_with: String
-  vault_not_ends_with_nocase: String
-  vault_: Vault_filter
-  amount: Bytes
-  amount_not: Bytes
-  amount_gt: Bytes
-  amount_lt: Bytes
-  amount_gte: Bytes
-  amount_lte: Bytes
-  amount_in: [Bytes!]
-  amount_not_in: [Bytes!]
-  amount_contains: Bytes
-  amount_not_contains: Bytes
-  oldVaultBalance: Bytes
-  oldVaultBalance_not: Bytes
-  oldVaultBalance_gt: Bytes
-  oldVaultBalance_lt: Bytes
-  oldVaultBalance_gte: Bytes
-  oldVaultBalance_lte: Bytes
-  oldVaultBalance_in: [Bytes!]
-  oldVaultBalance_not_in: [Bytes!]
-  oldVaultBalance_contains: Bytes
-  oldVaultBalance_not_contains: Bytes
-  newVaultBalance: Bytes
-  newVaultBalance_not: Bytes
-  newVaultBalance_gt: Bytes
-  newVaultBalance_lt: Bytes
-  newVaultBalance_gte: Bytes
-  newVaultBalance_lte: Bytes
-  newVaultBalance_in: [Bytes!]
-  newVaultBalance_not_in: [Bytes!]
-  newVaultBalance_contains: Bytes
-  newVaultBalance_not_contains: Bytes
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
+  trade_not_in: [String!]
+  trade_not_starts_with: String
+  trade_not_starts_with_nocase: String
+  trade_starts_with: String
+  trade_starts_with_nocase: String
   transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
+  transaction_: Transaction_filter
   transaction_contains: String
   transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
   transaction_ends_with: String
   transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
   transaction_not_ends_with: String
   transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [TradeVaultBalanceChange_filter]
-  or: [TradeVaultBalanceChange_filter]
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
+  vault: String
+  vault_: Vault_filter
+  vault_contains: String
+  vault_contains_nocase: String
+  vault_ends_with: String
+  vault_ends_with_nocase: String
+  vault_gt: String
+  vault_gte: String
+  vault_in: [String!]
+  vault_lt: String
+  vault_lte: String
+  vault_not: String
+  vault_not_contains: String
+  vault_not_contains_nocase: String
+  vault_not_ends_with: String
+  vault_not_ends_with_nocase: String
+  vault_not_in: [String!]
+  vault_not_starts_with: String
+  vault_not_starts_with_nocase: String
+  vault_starts_with: String
+  vault_starts_with_nocase: String
 }
 
 enum TradeVaultBalanceChange_orderBy {
+  amount
   id
+  newVaultBalance
+  oldVaultBalance
   raindex
   raindex__id
+  timestamp
   trade
   trade__id
   trade__timestamp
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
   vault
+  vault__balance
   vault__id
   vault__owner
   vault__vaultId
-  vault__balance
-  amount
-  oldVaultBalance
-  newVaultBalance
+}
+
+input Trade_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Trade_filter]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  inputVaultBalanceChange: String
+  inputVaultBalanceChange_: TradeVaultBalanceChange_filter
+  inputVaultBalanceChange_contains: String
+  inputVaultBalanceChange_contains_nocase: String
+  inputVaultBalanceChange_ends_with: String
+  inputVaultBalanceChange_ends_with_nocase: String
+  inputVaultBalanceChange_gt: String
+  inputVaultBalanceChange_gte: String
+  inputVaultBalanceChange_in: [String!]
+  inputVaultBalanceChange_lt: String
+  inputVaultBalanceChange_lte: String
+  inputVaultBalanceChange_not: String
+  inputVaultBalanceChange_not_contains: String
+  inputVaultBalanceChange_not_contains_nocase: String
+  inputVaultBalanceChange_not_ends_with: String
+  inputVaultBalanceChange_not_ends_with_nocase: String
+  inputVaultBalanceChange_not_in: [String!]
+  inputVaultBalanceChange_not_starts_with: String
+  inputVaultBalanceChange_not_starts_with_nocase: String
+  inputVaultBalanceChange_starts_with: String
+  inputVaultBalanceChange_starts_with_nocase: String
+  or: [Trade_filter]
+  order: String
+  order_: Order_filter
+  order_contains: String
+  order_contains_nocase: String
+  order_ends_with: String
+  order_ends_with_nocase: String
+  order_gt: String
+  order_gte: String
+  order_in: [String!]
+  order_lt: String
+  order_lte: String
+  order_not: String
+  order_not_contains: String
+  order_not_contains_nocase: String
+  order_not_ends_with: String
+  order_not_ends_with_nocase: String
+  order_not_in: [String!]
+  order_not_starts_with: String
+  order_not_starts_with_nocase: String
+  order_starts_with: String
+  order_starts_with_nocase: String
+  outputVaultBalanceChange: String
+  outputVaultBalanceChange_: TradeVaultBalanceChange_filter
+  outputVaultBalanceChange_contains: String
+  outputVaultBalanceChange_contains_nocase: String
+  outputVaultBalanceChange_ends_with: String
+  outputVaultBalanceChange_ends_with_nocase: String
+  outputVaultBalanceChange_gt: String
+  outputVaultBalanceChange_gte: String
+  outputVaultBalanceChange_in: [String!]
+  outputVaultBalanceChange_lt: String
+  outputVaultBalanceChange_lte: String
+  outputVaultBalanceChange_not: String
+  outputVaultBalanceChange_not_contains: String
+  outputVaultBalanceChange_not_contains_nocase: String
+  outputVaultBalanceChange_not_ends_with: String
+  outputVaultBalanceChange_not_ends_with_nocase: String
+  outputVaultBalanceChange_not_in: [String!]
+  outputVaultBalanceChange_not_starts_with: String
+  outputVaultBalanceChange_not_starts_with_nocase: String
+  outputVaultBalanceChange_starts_with: String
+  outputVaultBalanceChange_starts_with_nocase: String
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  timestamp: BigInt
+  timestamp_gt: BigInt
+  timestamp_gte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
+  timestamp_not_in: [BigInt!]
+  tradeEvent: String
+  tradeEvent_: TradeEvent_filter
+  tradeEvent_contains: String
+  tradeEvent_contains_nocase: String
+  tradeEvent_ends_with: String
+  tradeEvent_ends_with_nocase: String
+  tradeEvent_gt: String
+  tradeEvent_gte: String
+  tradeEvent_in: [String!]
+  tradeEvent_lt: String
+  tradeEvent_lte: String
+  tradeEvent_not: String
+  tradeEvent_not_contains: String
+  tradeEvent_not_contains_nocase: String
+  tradeEvent_not_ends_with: String
+  tradeEvent_not_ends_with_nocase: String
+  tradeEvent_not_in: [String!]
+  tradeEvent_not_starts_with: String
+  tradeEvent_not_starts_with_nocase: String
+  tradeEvent_starts_with: String
+  tradeEvent_starts_with_nocase: String
+}
+
+enum Trade_orderBy {
+  id
+  inputVaultBalanceChange
+  inputVaultBalanceChange__amount
+  inputVaultBalanceChange__id
+  inputVaultBalanceChange__newVaultBalance
+  inputVaultBalanceChange__oldVaultBalance
+  inputVaultBalanceChange__timestamp
+  order
+  order__active
+  order__id
+  order__meta
+  order__nonce
+  order__orderBytes
+  order__orderHash
+  order__owner
+  order__timestampAdded
+  outputVaultBalanceChange
+  outputVaultBalanceChange__amount
+  outputVaultBalanceChange__id
+  outputVaultBalanceChange__newVaultBalance
+  outputVaultBalanceChange__oldVaultBalance
+  outputVaultBalanceChange__timestamp
+  raindex
+  raindex__id
   timestamp
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
+  tradeEvent
+  tradeEvent__id
+  tradeEvent__sender
 }
 
 type Transaction {
+  blockNumber: BigInt!
+  events(first: Int = 100, orderBy: Event_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Event_filter): [Event!]
+  from: Bytes!
   id: Bytes!
   timestamp: BigInt!
-  blockNumber: BigInt!
-  from: Bytes!
-  events(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Event_orderBy
-    orderDirection: OrderDirection
-    where: Event_filter
-  ): [Event!]
 }
 
 input Transaction_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  timestamp: BigInt
-  timestamp_not: BigInt
-  timestamp_gt: BigInt
-  timestamp_lt: BigInt
-  timestamp_gte: BigInt
-  timestamp_lte: BigInt
-  timestamp_in: [BigInt!]
-  timestamp_not_in: [BigInt!]
-  blockNumber: BigInt
-  blockNumber_not: BigInt
-  blockNumber_gt: BigInt
-  blockNumber_lt: BigInt
-  blockNumber_gte: BigInt
-  blockNumber_lte: BigInt
-  blockNumber_in: [BigInt!]
-  blockNumber_not_in: [BigInt!]
-  from: Bytes
-  from_not: Bytes
-  from_gt: Bytes
-  from_lt: Bytes
-  from_gte: Bytes
-  from_lte: Bytes
-  from_in: [Bytes!]
-  from_not_in: [Bytes!]
-  from_contains: Bytes
-  from_not_contains: Bytes
-  events_: Event_filter
-
-  """
-  Filter for the block changed event.
-  """
+  """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Transaction_filter]
+  blockNumber: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_lt: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_not: BigInt
+  blockNumber_not_in: [BigInt!]
+  events_: Event_filter
+  from: Bytes
+  from_contains: Bytes
+  from_gt: Bytes
+  from_gte: Bytes
+  from_in: [Bytes!]
+  from_lt: Bytes
+  from_lte: Bytes
+  from_not: Bytes
+  from_not_contains: Bytes
+  from_not_in: [Bytes!]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
   or: [Transaction_filter]
+  timestamp: BigInt
+  timestamp_gt: BigInt
+  timestamp_gte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
+  timestamp_not_in: [BigInt!]
 }
 
 enum Transaction_orderBy {
+  blockNumber
+  events
+  from
   id
   timestamp
-  blockNumber
-  from
-  events
 }
 
 type Vault {
-  id: Bytes!
-
-  """
-  The raindex this vault is in
-  """
-  raindex: Raindex!
-
-  """
-  The token that this vault is for
-  """
-  token: ERC20!
-
-  """
-  The owner of this vault
-  """
-  owner: Bytes!
-
-  """
-  The vaultId of this vault
-  """
-  vaultId: Bytes!
-
-  """
-  Orders this vault is an input for
-  """
-  ordersAsInput(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Order_orderBy
-    orderDirection: OrderDirection
-    where: Order_filter
-  ): [Order!]!
-
-  """
-  Orders this vault is an output for
-  """
-  ordersAsOutput(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: Order_orderBy
-    orderDirection: OrderDirection
-    where: Order_filter
-  ): [Order!]!
-
-  """
-  The amount of the token that is in this vault
-  """
+  """The amount of the token that is in this vault"""
   balance: Bytes!
 
-  """
-  All balance changes for this vault
-  """
-  balanceChanges(
-    skip: Int = 0
-    first: Int = 100
-    orderBy: VaultBalanceChange_orderBy
-    orderDirection: OrderDirection
-    where: VaultBalanceChange_filter
-  ): [VaultBalanceChange!]!
-}
+  """All balance changes for this vault"""
+  balanceChanges(first: Int = 100, orderBy: VaultBalanceChange_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: VaultBalanceChange_filter): [VaultBalanceChange!]!
+  id: Bytes!
 
-input Vault_filter {
-  id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
-  id_contains: Bytes
-  id_not_contains: Bytes
-  raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
-  raindex_contains: String
-  raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
-  raindex_ends_with: String
-  raindex_ends_with_nocase: String
-  raindex_not_ends_with: String
-  raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  token: String
-  token_not: String
-  token_gt: String
-  token_lt: String
-  token_gte: String
-  token_lte: String
-  token_in: [String!]
-  token_not_in: [String!]
-  token_contains: String
-  token_contains_nocase: String
-  token_not_contains: String
-  token_not_contains_nocase: String
-  token_starts_with: String
-  token_starts_with_nocase: String
-  token_not_starts_with: String
-  token_not_starts_with_nocase: String
-  token_ends_with: String
-  token_ends_with_nocase: String
-  token_not_ends_with: String
-  token_not_ends_with_nocase: String
-  token_: ERC20_filter
-  owner: Bytes
-  owner_not: Bytes
-  owner_gt: Bytes
-  owner_lt: Bytes
-  owner_gte: Bytes
-  owner_lte: Bytes
-  owner_in: [Bytes!]
-  owner_not_in: [Bytes!]
-  owner_contains: Bytes
-  owner_not_contains: Bytes
-  vaultId: Bytes
-  vaultId_not: Bytes
-  vaultId_gt: Bytes
-  vaultId_lt: Bytes
-  vaultId_gte: Bytes
-  vaultId_lte: Bytes
-  vaultId_in: [Bytes!]
-  vaultId_not_in: [Bytes!]
-  vaultId_contains: Bytes
-  vaultId_not_contains: Bytes
-  ordersAsInput_: Order_filter
-  ordersAsOutput_: Order_filter
-  balance: Bytes
-  balance_not: Bytes
-  balance_gt: Bytes
-  balance_lt: Bytes
-  balance_gte: Bytes
-  balance_lte: Bytes
-  balance_in: [Bytes!]
-  balance_not_in: [Bytes!]
-  balance_contains: Bytes
-  balance_not_contains: Bytes
-  balanceChanges_: VaultBalanceChange_filter
+  """Orders this vault is an input for"""
+  ordersAsInput(first: Int = 100, orderBy: Order_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Order_filter): [Order!]!
 
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Vault_filter]
-  or: [Vault_filter]
-}
+  """Orders this vault is an output for"""
+  ordersAsOutput(first: Int = 100, orderBy: Order_orderBy, orderDirection: OrderDirection, skip: Int = 0, where: Order_filter): [Order!]!
 
-enum Vault_orderBy {
-  id
-  raindex
-  raindex__id
-  token
-  token__id
-  token__address
-  token__name
-  token__symbol
-  token__decimals
-  owner
-  vaultId
-  ordersAsInput
-  ordersAsOutput
-  balance
-  balanceChanges
+  """The owner of this vault"""
+  owner: Bytes!
+
+  """The raindex this vault is in"""
+  raindex: Raindex!
+
+  """The token that this vault is for"""
+  token: ERC20!
+
+  """The vaultId of this vault"""
+  vaultId: Bytes!
 }
 
 interface VaultBalanceChange {
-  """
-  The raindex this balance change is for
-  """
-  raindex: Raindex!
-
-  """
-  The vault that was affected
-  """
-  vault: Vault!
-
-  """
-  The amount changed - this is signed
-  """
+  """The amount changed - this is signed"""
   amount: Bytes!
 
-  """
-  The balance of the vault before the change
-  """
-  oldVaultBalance: Bytes!
-
-  """
-  The balance of the vault after the change
-  """
+  """The balance of the vault after the change"""
   newVaultBalance: Bytes!
 
-  """
-  The timestamp this balance change was executed
-  """
+  """The balance of the vault before the change"""
+  oldVaultBalance: Bytes!
+
+  """The raindex this balance change is for"""
+  raindex: Raindex!
+
+  """The timestamp this balance change was executed"""
   timestamp: BigInt!
 
-  """
-  The transaction in which this balance change was executed
-  """
+  """The transaction in which this balance change was executed"""
   transaction: Transaction!
+
+  """The vault that was affected"""
+  vault: Vault!
 }
 
 input VaultBalanceChange_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  amount: Bytes
+  amount_contains: Bytes
+  amount_gt: Bytes
+  amount_gte: Bytes
+  amount_in: [Bytes!]
+  amount_lt: Bytes
+  amount_lte: Bytes
+  amount_not: Bytes
+  amount_not_contains: Bytes
+  amount_not_in: [Bytes!]
+  and: [VaultBalanceChange_filter]
+  newVaultBalance: Bytes
+  newVaultBalance_contains: Bytes
+  newVaultBalance_gt: Bytes
+  newVaultBalance_gte: Bytes
+  newVaultBalance_in: [Bytes!]
+  newVaultBalance_lt: Bytes
+  newVaultBalance_lte: Bytes
+  newVaultBalance_not: Bytes
+  newVaultBalance_not_contains: Bytes
+  newVaultBalance_not_in: [Bytes!]
+  oldVaultBalance: Bytes
+  oldVaultBalance_contains: Bytes
+  oldVaultBalance_gt: Bytes
+  oldVaultBalance_gte: Bytes
+  oldVaultBalance_in: [Bytes!]
+  oldVaultBalance_lt: Bytes
+  oldVaultBalance_lte: Bytes
+  oldVaultBalance_not: Bytes
+  oldVaultBalance_not_contains: Bytes
+  oldVaultBalance_not_in: [Bytes!]
+  or: [VaultBalanceChange_filter]
   raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
+  raindex_: Raindex_filter
   raindex_contains: String
   raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
   raindex_ends_with: String
   raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
   raindex_not_ends_with: String
   raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  vault: String
-  vault_not: String
-  vault_gt: String
-  vault_lt: String
-  vault_gte: String
-  vault_lte: String
-  vault_in: [String!]
-  vault_not_in: [String!]
-  vault_contains: String
-  vault_contains_nocase: String
-  vault_not_contains: String
-  vault_not_contains_nocase: String
-  vault_starts_with: String
-  vault_starts_with_nocase: String
-  vault_not_starts_with: String
-  vault_not_starts_with_nocase: String
-  vault_ends_with: String
-  vault_ends_with_nocase: String
-  vault_not_ends_with: String
-  vault_not_ends_with_nocase: String
-  vault_: Vault_filter
-  amount: Bytes
-  amount_not: Bytes
-  amount_gt: Bytes
-  amount_lt: Bytes
-  amount_gte: Bytes
-  amount_lte: Bytes
-  amount_in: [Bytes!]
-  amount_not_in: [Bytes!]
-  amount_contains: Bytes
-  amount_not_contains: Bytes
-  oldVaultBalance: Bytes
-  oldVaultBalance_not: Bytes
-  oldVaultBalance_gt: Bytes
-  oldVaultBalance_lt: Bytes
-  oldVaultBalance_gte: Bytes
-  oldVaultBalance_lte: Bytes
-  oldVaultBalance_in: [Bytes!]
-  oldVaultBalance_not_in: [Bytes!]
-  oldVaultBalance_contains: Bytes
-  oldVaultBalance_not_contains: Bytes
-  newVaultBalance: Bytes
-  newVaultBalance_not: Bytes
-  newVaultBalance_gt: Bytes
-  newVaultBalance_lt: Bytes
-  newVaultBalance_gte: Bytes
-  newVaultBalance_lte: Bytes
-  newVaultBalance_in: [Bytes!]
-  newVaultBalance_not_in: [Bytes!]
-  newVaultBalance_contains: Bytes
-  newVaultBalance_not_contains: Bytes
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
   timestamp: BigInt
-  timestamp_not: BigInt
   timestamp_gt: BigInt
-  timestamp_lt: BigInt
   timestamp_gte: BigInt
-  timestamp_lte: BigInt
   timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
   timestamp_not_in: [BigInt!]
   transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
+  transaction_: Transaction_filter
   transaction_contains: String
   transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
   transaction_ends_with: String
   transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
   transaction_not_ends_with: String
   transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [VaultBalanceChange_filter]
-  or: [VaultBalanceChange_filter]
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
+  vault: String
+  vault_: Vault_filter
+  vault_contains: String
+  vault_contains_nocase: String
+  vault_ends_with: String
+  vault_ends_with_nocase: String
+  vault_gt: String
+  vault_gte: String
+  vault_in: [String!]
+  vault_lt: String
+  vault_lte: String
+  vault_not: String
+  vault_not_contains: String
+  vault_not_contains_nocase: String
+  vault_not_ends_with: String
+  vault_not_ends_with_nocase: String
+  vault_not_in: [String!]
+  vault_not_starts_with: String
+  vault_not_starts_with_nocase: String
+  vault_starts_with: String
+  vault_starts_with_nocase: String
 }
 
 enum VaultBalanceChange_orderBy {
+  amount
+  newVaultBalance
+  oldVaultBalance
   raindex
   raindex__id
+  timestamp
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
   vault
+  vault__balance
   vault__id
   vault__owner
   vault__vaultId
-  vault__balance
-  amount
-  oldVaultBalance
-  newVaultBalance
-  timestamp
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
+}
+
+input Vault_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Vault_filter]
+  balance: Bytes
+  balanceChanges_: VaultBalanceChange_filter
+  balance_contains: Bytes
+  balance_gt: Bytes
+  balance_gte: Bytes
+  balance_in: [Bytes!]
+  balance_lt: Bytes
+  balance_lte: Bytes
+  balance_not: Bytes
+  balance_not_contains: Bytes
+  balance_not_in: [Bytes!]
+  id: Bytes
+  id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
+  id_not_contains: Bytes
+  id_not_in: [Bytes!]
+  or: [Vault_filter]
+  ordersAsInput_: Order_filter
+  ordersAsOutput_: Order_filter
+  owner: Bytes
+  owner_contains: Bytes
+  owner_gt: Bytes
+  owner_gte: Bytes
+  owner_in: [Bytes!]
+  owner_lt: Bytes
+  owner_lte: Bytes
+  owner_not: Bytes
+  owner_not_contains: Bytes
+  owner_not_in: [Bytes!]
+  raindex: String
+  raindex_: Raindex_filter
+  raindex_contains: String
+  raindex_contains_nocase: String
+  raindex_ends_with: String
+  raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
+  raindex_not_ends_with: String
+  raindex_not_ends_with_nocase: String
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  token: String
+  token_: ERC20_filter
+  token_contains: String
+  token_contains_nocase: String
+  token_ends_with: String
+  token_ends_with_nocase: String
+  token_gt: String
+  token_gte: String
+  token_in: [String!]
+  token_lt: String
+  token_lte: String
+  token_not: String
+  token_not_contains: String
+  token_not_contains_nocase: String
+  token_not_ends_with: String
+  token_not_ends_with_nocase: String
+  token_not_in: [String!]
+  token_not_starts_with: String
+  token_not_starts_with_nocase: String
+  token_starts_with: String
+  token_starts_with_nocase: String
+  vaultId: Bytes
+  vaultId_contains: Bytes
+  vaultId_gt: Bytes
+  vaultId_gte: Bytes
+  vaultId_in: [Bytes!]
+  vaultId_lt: Bytes
+  vaultId_lte: Bytes
+  vaultId_not: Bytes
+  vaultId_not_contains: Bytes
+  vaultId_not_in: [Bytes!]
+}
+
+enum Vault_orderBy {
+  balance
+  balanceChanges
+  id
+  ordersAsInput
+  ordersAsOutput
+  owner
+  raindex
+  raindex__id
+  token
+  token__address
+  token__decimals
+  token__id
+  token__name
+  token__symbol
+  vaultId
 }
 
 type Withdrawal implements Event & VaultBalanceChange {
+  """The amount that was actually withdrawn - this will be negative"""
+  amount: Bytes!
   id: Bytes!
+  newVaultBalance: Bytes!
+  oldVaultBalance: Bytes!
 
-  """
-  The amount that was being targeted to be withdrawn
-  """
-  targetAmount: Bytes!
-
-  """
-  The raindex this balance change is for
-  """
+  """The raindex this balance change is for"""
   raindex: Raindex!
 
-  """
-  The vault that was withdrawn from
-  """
-  vault: Vault!
+  """The msg.sender of this withdrawal"""
+  sender: Bytes!
 
-  """
-  The amount that was actually withdrawn - this will be negative
-  """
-  amount: Bytes!
-  oldVaultBalance: Bytes!
-  newVaultBalance: Bytes!
+  """The amount that was being targeted to be withdrawn"""
+  targetAmount: Bytes!
 
-  """
-  The timestamp this balance change was executed
-  """
+  """The timestamp this balance change was executed"""
   timestamp: BigInt!
   transaction: Transaction!
 
-  """
-  The msg.sender of this withdrawal
-  """
-  sender: Bytes!
+  """The vault that was withdrawn from"""
+  vault: Vault!
 }
 
 input Withdrawal_filter {
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  amount: Bytes
+  amount_contains: Bytes
+  amount_gt: Bytes
+  amount_gte: Bytes
+  amount_in: [Bytes!]
+  amount_lt: Bytes
+  amount_lte: Bytes
+  amount_not: Bytes
+  amount_not_contains: Bytes
+  amount_not_in: [Bytes!]
+  and: [Withdrawal_filter]
   id: Bytes
-  id_not: Bytes
-  id_gt: Bytes
-  id_lt: Bytes
-  id_gte: Bytes
-  id_lte: Bytes
-  id_in: [Bytes!]
-  id_not_in: [Bytes!]
   id_contains: Bytes
+  id_gt: Bytes
+  id_gte: Bytes
+  id_in: [Bytes!]
+  id_lt: Bytes
+  id_lte: Bytes
+  id_not: Bytes
   id_not_contains: Bytes
-  targetAmount: Bytes
-  targetAmount_not: Bytes
-  targetAmount_gt: Bytes
-  targetAmount_lt: Bytes
-  targetAmount_gte: Bytes
-  targetAmount_lte: Bytes
-  targetAmount_in: [Bytes!]
-  targetAmount_not_in: [Bytes!]
-  targetAmount_contains: Bytes
-  targetAmount_not_contains: Bytes
+  id_not_in: [Bytes!]
+  newVaultBalance: Bytes
+  newVaultBalance_contains: Bytes
+  newVaultBalance_gt: Bytes
+  newVaultBalance_gte: Bytes
+  newVaultBalance_in: [Bytes!]
+  newVaultBalance_lt: Bytes
+  newVaultBalance_lte: Bytes
+  newVaultBalance_not: Bytes
+  newVaultBalance_not_contains: Bytes
+  newVaultBalance_not_in: [Bytes!]
+  oldVaultBalance: Bytes
+  oldVaultBalance_contains: Bytes
+  oldVaultBalance_gt: Bytes
+  oldVaultBalance_gte: Bytes
+  oldVaultBalance_in: [Bytes!]
+  oldVaultBalance_lt: Bytes
+  oldVaultBalance_lte: Bytes
+  oldVaultBalance_not: Bytes
+  oldVaultBalance_not_contains: Bytes
+  oldVaultBalance_not_in: [Bytes!]
+  or: [Withdrawal_filter]
   raindex: String
-  raindex_not: String
-  raindex_gt: String
-  raindex_lt: String
-  raindex_gte: String
-  raindex_lte: String
-  raindex_in: [String!]
-  raindex_not_in: [String!]
+  raindex_: Raindex_filter
   raindex_contains: String
   raindex_contains_nocase: String
-  raindex_not_contains: String
-  raindex_not_contains_nocase: String
-  raindex_starts_with: String
-  raindex_starts_with_nocase: String
-  raindex_not_starts_with: String
-  raindex_not_starts_with_nocase: String
   raindex_ends_with: String
   raindex_ends_with_nocase: String
+  raindex_gt: String
+  raindex_gte: String
+  raindex_in: [String!]
+  raindex_lt: String
+  raindex_lte: String
+  raindex_not: String
+  raindex_not_contains: String
+  raindex_not_contains_nocase: String
   raindex_not_ends_with: String
   raindex_not_ends_with_nocase: String
-  raindex_: Raindex_filter
-  vault: String
-  vault_not: String
-  vault_gt: String
-  vault_lt: String
-  vault_gte: String
-  vault_lte: String
-  vault_in: [String!]
-  vault_not_in: [String!]
-  vault_contains: String
-  vault_contains_nocase: String
-  vault_not_contains: String
-  vault_not_contains_nocase: String
-  vault_starts_with: String
-  vault_starts_with_nocase: String
-  vault_not_starts_with: String
-  vault_not_starts_with_nocase: String
-  vault_ends_with: String
-  vault_ends_with_nocase: String
-  vault_not_ends_with: String
-  vault_not_ends_with_nocase: String
-  vault_: Vault_filter
-  amount: Bytes
-  amount_not: Bytes
-  amount_gt: Bytes
-  amount_lt: Bytes
-  amount_gte: Bytes
-  amount_lte: Bytes
-  amount_in: [Bytes!]
-  amount_not_in: [Bytes!]
-  amount_contains: Bytes
-  amount_not_contains: Bytes
-  oldVaultBalance: Bytes
-  oldVaultBalance_not: Bytes
-  oldVaultBalance_gt: Bytes
-  oldVaultBalance_lt: Bytes
-  oldVaultBalance_gte: Bytes
-  oldVaultBalance_lte: Bytes
-  oldVaultBalance_in: [Bytes!]
-  oldVaultBalance_not_in: [Bytes!]
-  oldVaultBalance_contains: Bytes
-  oldVaultBalance_not_contains: Bytes
-  newVaultBalance: Bytes
-  newVaultBalance_not: Bytes
-  newVaultBalance_gt: Bytes
-  newVaultBalance_lt: Bytes
-  newVaultBalance_gte: Bytes
-  newVaultBalance_lte: Bytes
-  newVaultBalance_in: [Bytes!]
-  newVaultBalance_not_in: [Bytes!]
-  newVaultBalance_contains: Bytes
-  newVaultBalance_not_contains: Bytes
+  raindex_not_in: [String!]
+  raindex_not_starts_with: String
+  raindex_not_starts_with_nocase: String
+  raindex_starts_with: String
+  raindex_starts_with_nocase: String
+  sender: Bytes
+  sender_contains: Bytes
+  sender_gt: Bytes
+  sender_gte: Bytes
+  sender_in: [Bytes!]
+  sender_lt: Bytes
+  sender_lte: Bytes
+  sender_not: Bytes
+  sender_not_contains: Bytes
+  sender_not_in: [Bytes!]
+  targetAmount: Bytes
+  targetAmount_contains: Bytes
+  targetAmount_gt: Bytes
+  targetAmount_gte: Bytes
+  targetAmount_in: [Bytes!]
+  targetAmount_lt: Bytes
+  targetAmount_lte: Bytes
+  targetAmount_not: Bytes
+  targetAmount_not_contains: Bytes
+  targetAmount_not_in: [Bytes!]
   timestamp: BigInt
-  timestamp_not: BigInt
   timestamp_gt: BigInt
-  timestamp_lt: BigInt
   timestamp_gte: BigInt
-  timestamp_lte: BigInt
   timestamp_in: [BigInt!]
+  timestamp_lt: BigInt
+  timestamp_lte: BigInt
+  timestamp_not: BigInt
   timestamp_not_in: [BigInt!]
   transaction: String
-  transaction_not: String
-  transaction_gt: String
-  transaction_lt: String
-  transaction_gte: String
-  transaction_lte: String
-  transaction_in: [String!]
-  transaction_not_in: [String!]
+  transaction_: Transaction_filter
   transaction_contains: String
   transaction_contains_nocase: String
-  transaction_not_contains: String
-  transaction_not_contains_nocase: String
-  transaction_starts_with: String
-  transaction_starts_with_nocase: String
-  transaction_not_starts_with: String
-  transaction_not_starts_with_nocase: String
   transaction_ends_with: String
   transaction_ends_with_nocase: String
+  transaction_gt: String
+  transaction_gte: String
+  transaction_in: [String!]
+  transaction_lt: String
+  transaction_lte: String
+  transaction_not: String
+  transaction_not_contains: String
+  transaction_not_contains_nocase: String
   transaction_not_ends_with: String
   transaction_not_ends_with_nocase: String
-  transaction_: Transaction_filter
-  sender: Bytes
-  sender_not: Bytes
-  sender_gt: Bytes
-  sender_lt: Bytes
-  sender_gte: Bytes
-  sender_lte: Bytes
-  sender_in: [Bytes!]
-  sender_not_in: [Bytes!]
-  sender_contains: Bytes
-  sender_not_contains: Bytes
-
-  """
-  Filter for the block changed event.
-  """
-  _change_block: BlockChangedFilter
-  and: [Withdrawal_filter]
-  or: [Withdrawal_filter]
+  transaction_not_in: [String!]
+  transaction_not_starts_with: String
+  transaction_not_starts_with_nocase: String
+  transaction_starts_with: String
+  transaction_starts_with_nocase: String
+  vault: String
+  vault_: Vault_filter
+  vault_contains: String
+  vault_contains_nocase: String
+  vault_ends_with: String
+  vault_ends_with_nocase: String
+  vault_gt: String
+  vault_gte: String
+  vault_in: [String!]
+  vault_lt: String
+  vault_lte: String
+  vault_not: String
+  vault_not_contains: String
+  vault_not_contains_nocase: String
+  vault_not_ends_with: String
+  vault_not_ends_with_nocase: String
+  vault_not_in: [String!]
+  vault_not_starts_with: String
+  vault_not_starts_with_nocase: String
+  vault_starts_with: String
+  vault_starts_with_nocase: String
 }
 
 enum Withdrawal_orderBy {
+  amount
   id
-  targetAmount
+  newVaultBalance
+  oldVaultBalance
   raindex
   raindex__id
+  sender
+  targetAmount
+  timestamp
+  transaction
+  transaction__blockNumber
+  transaction__from
+  transaction__id
+  transaction__timestamp
   vault
+  vault__balance
   vault__id
   vault__owner
   vault__vaultId
-  vault__balance
-  amount
-  oldVaultBalance
-  newVaultBalance
-  timestamp
-  transaction
-  transaction__id
-  transaction__timestamp
-  transaction__blockNumber
-  transaction__from
-  sender
+}
+
+type _Block_ {
+  """The hash of the block"""
+  hash: Bytes
+
+  """The block number"""
+  number: Int!
+
+  """The hash of the parent block"""
+  parentHash: Bytes
+
+  """Integer representation of the timestamp stored in blocks for the chain"""
+  timestamp: Int
+}
+
+"""The type for the top-level _meta field"""
+type _Meta_ {
+  """
+  Information about a specific subgraph block. The hash of the block
+  will be null if the _meta field has a block constraint that asks for
+  a block number. It will be filled if the _meta field has no block constraint
+  and therefore asks for the latest  block
+  
+  """
+  block: _Block_!
+
+  """The deployment ID"""
+  deployment: String!
+
+  """If `true`, the subgraph encountered indexing errors at some past block"""
+  hasIndexingErrors: Boolean!
+}
+
+enum _SubgraphErrorPolicy_ {
+  """Data will be returned even if the subgraph has indexing errors"""
+  allow
+
+  """
+  If the subgraph has indexing errors, data will be omitted. The default.
+  """
+  deny
 }

--- a/subgraph/check-api-schema.sh
+++ b/subgraph/check-api-schema.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+snapshot=crates/subgraph/schema/raindex.graphql
+generated=raindex.graphql.generated
+subgraph_name=rain/raindex
+
+# Deployed in place, from the manifest as committed. Nothing here passes
+# `graph build --network`: subgraph.yaml already carries its network, address
+# and startBlock, and `--network` is what would write a networks.json entry
+# back into it.
+cd "$root/subgraph"
+npm ci
+graph build
+graph create --node http://localhost:8020/ "$subgraph_name"
+graph deploy \
+  --node http://localhost:8020/ \
+  --ipfs http://localhost:5001 \
+  --version-label ci \
+  "$subgraph_name"
+
+# graph-node derives the API schema at deploy time but refuses queries until
+# the deployment has ingested a block, so print-api-schema.js retries. Anvil's
+# block 0 is the whole of what has to be ingested.
+node ./print-api-schema.js "http://localhost:8000/subgraphs/name/$subgraph_name" \
+  > "$root/$generated"
+
+cd "$root"
+if ! diff -u "$snapshot" "$generated"; then
+  echo "$snapshot is not the API schema graph-node derives from subgraph/schema.graphql." >&2
+  echo "Copy $generated (uploaded by this job as an artifact) over it." >&2
+  exit 1
+fi

--- a/subgraph/docker-compose.graph-node.yml
+++ b/subgraph/docker-compose.graph-node.yml
@@ -1,0 +1,46 @@
+# A SEPARATE compose file from ./docker-compose.yml: rainix's `subgraph-test`
+# runs `docker compose up --abort-on-container-exit` over the default file in
+# this directory, so these long-lived services must not land in it.
+services:
+  postgres:
+    image: postgres:14
+    command: postgres -cshared_preload_libraries=pg_stat_statements
+    environment:
+      POSTGRES_USER: graph-node
+      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_DB: graph-node
+      POSTGRES_INITDB_ARGS: -E UTF8 --locale=C
+    healthcheck:
+      test: pg_isready -U graph-node
+      interval: 2s
+      timeout: 5s
+      retries: 30
+  ipfs:
+    image: ipfs/kubo:v0.17.0
+    ports:
+      - 5001:5001
+  graph-node:
+    image: graphprotocol/graph-node:v0.35.1
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ipfs:
+        condition: service_started
+    # graph-node will not accept a deployment naming a chain it has no adapter
+    # for, so anvil runs on the host and is reached over the docker gateway.
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    ports:
+      - 8000:8000
+      - 8020:8020
+      - 8030:8030
+    environment:
+      postgres_host: postgres
+      postgres_user: graph-node
+      postgres_pass: let-me-in
+      postgres_db: graph-node
+      ipfs: ipfs:5001
+      # Named for the network the committed manifest declares, so the manifest
+      # deploys as committed and nothing has to rewrite it.
+      ethereum: sepolia:http://host.docker.internal:8545
+      GRAPH_LOG: info

--- a/subgraph/package-lock.json
+++ b/subgraph/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@graphprotocol/graph-cli": "^0.63.0",
                 "@graphprotocol/graph-ts": "=0.32.0",
+                "graphql": "15.5.0",
                 "matchstick-as": "^0.6.0",
                 "source-map-support": "^0.5.21"
             }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -10,6 +10,7 @@
     "dependencies": {
         "@graphprotocol/graph-cli": "^0.63.0",
         "@graphprotocol/graph-ts": "=0.32.0",
+        "graphql": "15.5.0",
         "matchstick-as": "^0.6.0",
         "source-map-support": "^0.5.21"
     }

--- a/subgraph/print-api-schema.js
+++ b/subgraph/print-api-schema.js
@@ -1,0 +1,61 @@
+const {
+  buildClientSchema,
+  getIntrospectionQuery,
+  lexicographicSortSchema,
+  printSchema,
+} = require("graphql");
+
+const endpoint = process.argv[2];
+const attempts = 30;
+const delayMs = 2000;
+const timeoutMs = 10000;
+
+async function introspect() {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query: getIntrospectionQuery() }),
+    // Bounded, because a graph-node that accepts the connection and then
+    // stalls would hang this await and the retry below would never run. The
+    // signal covers reading the body, not just the headers.
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const body = await response.json();
+  if (body.errors) {
+    throw new Error(JSON.stringify(body.errors));
+  }
+  return body.data;
+}
+
+async function main() {
+  if (!endpoint) {
+    throw new Error("usage: print-api-schema.js <graphql endpoint>");
+  }
+  let last;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const introspection = await introspect();
+      // Sorted, because the order introspection reports types and fields in is
+      // graph-node's own and is not what the snapshot is asserting.
+      process.stdout.write(
+        printSchema(lexicographicSortSchema(buildClientSchema(introspection))),
+      );
+      return;
+    } catch (error) {
+      last = error;
+      console.error(
+        `${endpoint}: attempt ${attempt}/${attempts}: ${error.message}`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw last;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #2852.

`crates/subgraph/schema/raindex.graphql` is the graph-node API schema, and
`cynic_codegen` in `crates/subgraph/build.rs` registers it as truth for the
generated client. Nothing in this repo produced it and nothing checked it, so a
wrong hand-edit compiled fine and only surfaced against a live endpoint at
runtime.

It cannot be regenerated offline the way `copy-artifacts` regenerates the ABIs
— reproducing it means running graph-node's own schema derivation. So this runs
graph-node.

## The job

`schema-snapshot`, a second job in `Subgraph unit tests`:

- `anvil` from `.#sol-shell` on the runner host, reached by graph-node over the
  docker host gateway. graph-node will not accept a deployment naming a chain
  it has no adapter for.
- postgres + ipfs + graph-node from `subgraph/docker-compose.graph-node.yml`, a
  SEPARATE compose file: rainix's `subgraph-test` runs `docker compose up
  --abort-on-container-exit` over `subgraph/docker-compose.yml`, so these
  services must not land in it.
- `subgraph/check-api-schema.sh` runs `npm ci`, `graph build`, `graph create`,
  `graph deploy` in `subgraph/` as committed.
- `subgraph/print-api-schema.js` introspects the deployed endpoint and prints
  the SDL through `lexicographicSortSchema`, so the snapshot does not encode
  graph-node's internal type ordering. It retries: graph-node answers
  `Subgraph ... has not started syncing yet` for the first second or two after
  a deploy.
- `diff -u` against the committed snapshot, with the derived schema uploaded as
  an artifact so a mismatch is fixed by copying the artifact over the file.

The job asserts `git diff --exit-code -- subgraph/` after, so build residue in
the source tree fails the job rather than being committed by accident.

## What it found immediately

The committed snapshot was wrong. It is replaced here, verbatim from the job's
own artifact — 4534 lines to 3681.

Ignoring formatting, the difference is exactly four records — two interface
lists and two field names:

- `type Clear implements TradeEvent` and `type TakeOrder implements TradeEvent`
  where `subgraph/schema.graphql` declares both as `implements Event &
  TradeEvent`. The snapshot dropped `Event` from the interface list on both.
- `raindexs` on `Query` and on `Subscription`, where graph-node pluralises
  `Raindex` to `raindices`. Nothing in the repo queried that field, so it
  compiled.

The rest of the churn is canonical form, not content: the 281 descriptions in
the file are identical as text between the two, and the old file kept
graph-node's natural argument order where `lexicographicSortSchema` sorts
arguments, hard-wrapped descriptions that `printSchema` emits on one line, and
spread argument lists over multiple lines that `printSchema` prints inline.

## Adapted from rainlanguage/rain.metadata#298, for rainlanguage/rainix#365

#298 is the reference. What had to change here, and why — this is the seam the
reusable workflow has to be able to straddle:

1. **No temp tree and no throwaway `networks.json`.** #298 copies `subgraph/`
   plus the ABIs its manifest names into a temp dir and synthesises a
   `networks.json` there, because rain.metadata's manifest is a template
   carrying no `address`/`startBlock` and `graph build --network` writes that
   network's values back into the manifest it builds. raindex's
   `subgraph/subgraph.yaml` already carries `network`, `address` and
   `startBlock`, so nothing here passes `--network`, nothing rewrites the
   manifest, and the build runs in place. **`--network` is the whole reason for
   the temp tree** — it is not part of the intersection, it is conditional on a
   network being selected at build time. A reusable workflow has to take that
   as an input rather than always doing it.
2. **graph-node's chain is named after the manifest, not the reverse.** #298
   names the chain `anvil` and rewrites the manifest onto that network. Here
   the compose file declares `ethereum: sepolia:http://host.docker.internal:8545`
   — the name graph-node is told is the one the committed manifest already
   declares — and anvil runs with `--chain-id 11155111` so that name is not a
   lie. The chain name is a per-repo input derived from the manifest.
3. **No `forge soldeer install` and no `forge build`.** #298 needs both because
   rain.metadata's manifest points at ABIs forge emits. raindex commits
   `subgraph/abis/*.json` — `deploy-subgraph.yaml` says so in as many words —
   so those two steps drop out entirely. An optional pre-build step, not a
   fixed one.
4. **No `graph codegen`.** #298 runs it. raindex commits
   `subgraph/generated/`, and `subgraph-deploy` builds straight off it; running
   codegen here would rewrite a committed directory and put the
   `git diff --exit-code -- subgraph/` assertion at risk of firing for a reason
   that has nothing to do with the schema.
5. **Two shells, not one.** #298 runs everything under rain.metadata's default
   `nix develop`. raindex's default shell carries the rust and wasm toolchains,
   so the job splits: `.#sol-shell` for `anvil`/`cast` only, `.#subgraph-shell`
   (node + graph-cli, no rust, no foundry) for deploy and introspection. Both
   are the flake's re-exports, so they come from `flake.lock`'s rainix rev
   rather than live `main`, per the comment on those outputs.
6. **The CI preamble is rainix's composite, not hand-rolled.** #298 had to
   hand-add `cachix/cachix-action` to its lane, because rain.metadata's
   subgraph lane is a hand-rolled workflow that predates the shared preamble.
   raindex's lane already calls `rainix-subgraph-test.yaml`, so this job uses
   `rainlanguage/rainix/.github/actions/nix-cachix-setup@main` and gets
   checkout, nix, cachix and the store cache from it. #298's "Also here" cachix
   fix has no analogue here — which is the clearest signal that the preamble is
   already correctly upstream and the reusable workflow should call the
   composite the same way.
7. **Every name is a parameter.** Snapshot path, derived-file name, artifact
   name and subgraph name all differ (`crates/subgraph/schema/raindex.graphql`,
   `raindex.graphql.generated`, `raindex-api-schema`, `rain/raindex`).

Carried over unchanged, and therefore the actual intersection: the separate
compose file (raindex has the same `subgraph/docker-compose.yml` collision
hazard with `--abort-on-container-exit`); the `graphql` 15.5.0 direct pin —
raindex's lock has the identical shape, graph-cli pinning `15.5.0` against
`@float-capital/float-subgraph-uncrashable` wanting `^16.6.0`, with npm's
hoist tie-break today landing on 15.5.0 and nothing holding it there;
`print-api-schema.js` byte for byte, including `AbortSignal.timeout` and the
retry loop; `lexicographicSortSchema` + `printSchema`; the `diff -u`; the
artifact upload; and the `graph-node:v0.35.1` / `postgres:14` / `kubo:v0.17.0`
pins.

One limitation worth stating: the assertion is only ever "matches what
graph-node **v0.35.1** derives". That pin is the oracle. If the deployment
target's graph-node moves, the pin has to move with it, and the snapshot churns
when it does.

## QA
- Discriminating tests: the `schema-snapshot` job itself — it is the test. It
  fails on base: at 4a57948, with `main`'s hand-maintained snapshot in the tree
  and this job already wired up, run
  [33038854396](https://github.com/rainlanguage/raindex/actions/runs/33038854396)
  went red at `Deploy the subgraph and diff the committed API schema`, diffing
  the committed file against what graph-node v0.35.1 derived. With the snapshot
  corrected it is green, all nine steps including the residue assertion: run
  [33039458785](https://github.com/rainlanguage/raindex/actions/runs/33039458785),
  2m52s.
- Mutations applied: `crates/subgraph/schema/raindex.graphql:24`
  `sender: Bytes!` → `sender: String!` in `type AddOrder`, pushed as commit
  bda92d4 on branch `2026-08-27-issue-2852-mutation` (left in place as the
  audit trail; it is not for merge) → killed by `schema-snapshot`, run
  [33039507532](https://github.com/rainlanguage/raindex/actions/runs/33039507532),
  red at the diff step reporting exactly `-  sender: String!` /
  `+  sender: Bytes!` and nothing else. The deploy and introspection steps
  before it passed — and the deployment hashed to the same
  `QmYTBj2rmrYBP1qjD7Q4nSarJJCnS4UaFYKKrviXkJpWto` as the green run, because
  only the snapshot moved — so the red is the assertion firing and not the
  harness falling over.
- The retry loop is load-bearing, not defensive decoration: every run so far
  logs `attempt 1/30: ... has not started syncing yet` and succeeds on attempt
  2.
- Oracle: graph-node itself. The expected schema is introspected out of a
  graph-node that was handed `subgraph/schema.graphql`; it is not derived from
  the committed file, nor from anything else in this repo. The four
  disagreements it forced on the committed snapshot are the oracle disagreeing
  with the artifact on first contact.
- Category check: the issue asks for (a) a CI job that deploys the subgraph to
  a throwaway graph-node, introspects it and fails on a difference, (b) the two
  findings from #298 carried over rather than rediscovered, (c) a check on
  whether the temp-tree/`networks.json` step applies here, (d) proof of red on
  a mutated snapshot. Covered: (a) the `schema-snapshot` job, (b) the `graphql`
  15.5.0 direct pin and the per-attempt `AbortSignal.timeout`, both carried
  verbatim, (c) it does not apply — see item 1 above, (d) run 33039507532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
