### PR TITLE
Rename the currency check to git-clean

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -1,7 +1,7 @@
-name: copy-artifacts
+name: Git is clean
 on: [push]
 jobs:
-  copy-artifacts:
+  git-clean:
     # Build from committed sources and assert the committed meta/pointer
     # artifacts are still current. The meta hook is `script/build-meta.sh`;
     # pointers + abis use the upstream Build.sol convention.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ pre-authorized; don't stop to ask about address/codehash churn.
 - Run `gh` via `nix shell nixpkgs#gh --command gh` (not on global PATH).
 - Required checks (`main` ruleset): `test`, `subgraph-test`, `test-js-bindings`,
   `wasm-artifacts`, `wasm-browser-test`, `wasm-test`. `rainix-sol / *`,
-  `copy-artifacts`, `Deploy-Preview-Push` and the ~30-min vercel preview do NOT
+  `git-clean`, `Deploy-Preview-Push` and the ~30-min vercel preview do NOT
   gate a merge. Still understand every red before merging; never `--admin` over
   an unexplained failure.
 - A merge-gate hook requires a
@@ -35,7 +35,7 @@ address + codehash. Do the whole cascade without asking:
 
 1. Regenerate artifacts — run the `rainix-copy-artifacts` step sequence (see
    that workflow) in `nix develop github:rainlanguage/rainix#sol-shell`. Stage
-   ALL changed artifacts or `copy-artifacts` drifts red.
+   ALL changed artifacts or `git-clean` drifts red.
 2. Deploy each changed suite:
    `gh workflow run manual-sol-artifacts.yaml --ref <branch> -f suite=<x>`. One
    dispatch deploys all seven chains. **Never run two deploys concurrently** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ pre-authorized; don't stop to ask about address/codehash churn.
 - Run `gh` via `nix shell nixpkgs#gh --command gh` (not on global PATH).
 - Required checks (`main` ruleset): `test`, `subgraph-test`, `test-js-bindings`,
   `wasm-artifacts`, `wasm-browser-test`, `wasm-test`. `rainix-sol / *`,
-  `git-clean`, `Deploy-Preview-Push` and the ~30-min vercel preview do NOT
-  gate a merge. Still understand every red before merging; never `--admin` over
-  an unexplained failure.
+  `git-clean`, `Deploy-Preview-Push` and the ~30-min vercel preview do NOT gate
+  a merge. Still understand every red before merging; never `--admin` over an
+  unexplained failure.
 - A merge-gate hook requires a
   `Reviewed <9-char-head-sha>: <substantive
   review>` PR comment bound to the


### PR DESCRIPTION
Closes #2853

Standardises the currency check on `git-clean`, all three names:

| | before | after |
|---|---|---|
| file | `.github/workflows/copy-artifacts.yaml` | `.github/workflows/git-clean.yaml` |
| workflow `name:` | `copy-artifacts` | `Git is clean` |
| job id | `copy-artifacts` | `git-clean` |

The job id is what shows in the checks list, so this is the name a reviewer
actually reads on a PR.

Unchanged: `rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main`
in the `uses:` line. rainix defines that reusable rather than consuming it, and
renaming it would break every consumer.

Also renamed the two `CLAUDE.md` references to this check by name (the required-checks
list and the artifact-regeneration cascade), which would otherwise name a check that no
longer exists. The `rainix-copy-artifacts` references in `CLAUDE.md` and `.prettierignore`
point at the reusable and are left alone.

## Branch protection

Checked before renaming. The `main` ruleset on this repo does have required status
checks, but `copy-artifacts` is **not** one of them — the required contexts are `test`,
`subgraph-test / subgraph-test`, `wasm-artifacts`, `wasm-test`, `wasm-browser-test` and
`test-js-bindings`. So this rename does not silently unrequire anything, and no
protection rule needs updating.

## QA
- Discriminating tests: n/a — the diff is a CI workflow rename plus two doc lines; there
  is no repo test that asserts a workflow's own name. The discriminating evidence is this
  PR's own check list: the job must appear with a `git-clean` caller segment and must not
  appear as `copy-artifacts / copy-artifacts`. Verified on the pushed head: it reads
  `git-clean / copy-artifacts` (see below).
- Mutations applied: n/a — no executable line changed. The one semantic hazard a mutation
  would probe (breaking the `uses:` line) is instead guarded by leaving that line byte-identical;
  `grep` over the diff confirms `rainix-copy-artifacts.yaml@main` is untouched.
- Oracle: #2853 states the target triple (file `git-clean.yaml`, `name: Git is clean`, job id
  `git-clean`), independently confirmed against the two already-conformant repos,
  rainlanguage/rain.solver and rainlanguage/rain.uniswap.
- Category check: the issue asks for three renames (file, workflow name, job id) and a
  branch-protection check before renaming; all four covered. Stale in-repo references to the
  old check name are included because leaving them is the searchability failure the issue is about.

## What the check context actually reads

Verified on this PR's live check list rather than assumed. Because this workflow calls a
**reusable**, GitHub names the check run `<caller job id> / <reusable job id>`, so the context is:

- before: `copy-artifacts / copy-artifacts`
- after: `git-clean / copy-artifacts`

The trailing `copy-artifacts` is the job id **inside**
`rainix/.github/workflows/rainix-copy-artifacts.yaml`, not anything this repo controls. This PR
does everything a consumer repo can do; the remaining half is a one-line job-id rename in rainix
itself. That rename would not break any `uses:` line — `uses:` resolves the workflow *file*, not a
job id — but it would change the context on every consumer at once, including the one repo that
requires it (rain.math.float.deploy), so it belongs in its own rainix change rather than here.

The fully-conformant repos (rain.solver, rain.uniswap) show a bare `git-clean` because they
hand-roll their steps instead of calling the reusable.
