### PR TITLE
Prompt to connect before the take-order form

### DIFF
--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -21,6 +21,15 @@ vi.mock('../lib/stores/wagmi', () => ({
 	signerAddress: mockSignerAddressStore
 }));
 
+vi.mock('@rainlanguage/ui-components', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@rainlanguage/ui-components')>();
+	const MockComponent = (await import('../lib/__mocks__/MockComponent.svelte')).default;
+	return {
+		...actual,
+		WalletConnect: MockComponent
+	};
+});
+
 const MOCK_RAINDEX_ADDRESS = '0x1234567890123456789012345678901234567890';
 const MOCK_SIGNER_ADDRESS = '0x9876543210987654321098765432109876543210';
 
@@ -392,14 +401,42 @@ describe('TakeOrderModal', () => {
 		await fireEvent.click(cancelButton);
 	});
 
-	it('shows WalletConnect when not connected', async () => {
+	it('prompts to connect and does not fetch quotes when the wallet is disconnected', async () => {
 		mockSignerAddressStore.mockSetSubscribeValue('');
 
 		render(TakeOrderModal, defaultProps);
 
 		await waitFor(() => {
-			expect(screen.queryByTestId('submit-button')).not.toBeInTheDocument();
+			expect(screen.getByText('Connect your wallet to continue.')).toBeInTheDocument();
 		});
+		expect(screen.getByTestId('mock-component')).toBeInTheDocument();
+		expect(screen.queryByTestId('submit-button')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('direction-buy')).not.toBeInTheDocument();
+		expect(screen.queryByText('Loading quotes...')).not.toBeInTheDocument();
+		expect(mockOrder.getQuotes).not.toHaveBeenCalled();
+	});
+
+	it('fetches quotes and shows the take form after the wallet connects', async () => {
+		mockSignerAddressStore.mockSetSubscribeValue('');
+		vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+			value: mockQuotes as never,
+			error: undefined
+		});
+
+		render(TakeOrderModal, defaultProps);
+
+		await waitFor(() => {
+			expect(screen.getByText('Connect your wallet to continue.')).toBeInTheDocument();
+		});
+		expect(mockOrder.getQuotes).not.toHaveBeenCalled();
+
+		mockSignerAddressStore.mockSetSubscribeValue(MOCK_SIGNER_ADDRESS);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('submit-button')).toBeInTheDocument();
+		});
+		expect(screen.queryByText('Connect your wallet to continue.')).not.toBeInTheDocument();
+		expect(mockOrder.getQuotes).toHaveBeenCalled();
 	});
 
 	it('shows submit button disabled initially', async () => {

--- a/packages/webapp/src/lib/components/TakeOrderModal.svelte
+++ b/packages/webapp/src/lib/components/TakeOrderModal.svelte
@@ -94,7 +94,7 @@
 		}
 	};
 
-	$: if (open && order) {
+	$: if (open && order && $signerAddress) {
 		loadQuotes();
 		startRefreshInterval();
 	} else {
@@ -271,7 +271,13 @@
 			sell and set your maximum acceptable price.
 		</p>
 
-		{#if isLoadingQuotes}
+		{#if !$signerAddress}
+			<p>Connect your wallet to continue.</p>
+			<div class="flex justify-end gap-2 pt-2">
+				<Button color="alternative" on:click={handleClose}>Cancel</Button>
+				<WalletConnect {appKitModal} {connected} />
+			</div>
+		{:else if isLoadingQuotes}
 			<div class="flex items-center justify-center py-8">
 				<Spinner size="8" />
 				<span class="ml-2">Loading quotes...</span>
@@ -475,18 +481,14 @@
 
 				<div class="flex justify-end gap-2 pt-2">
 					<Button color="alternative" on:click={handleClose}>Cancel</Button>
-					{#if $signerAddress}
-						<Button
-							color="blue"
-							disabled={!canSubmit}
-							on:click={handleSubmit}
-							data-testid="submit-button"
-						>
-							Take Order
-						</Button>
-					{:else}
-						<WalletConnect {appKitModal} {connected} />
-					{/if}
+					<Button
+						color="blue"
+						disabled={!canSubmit}
+						on:click={handleSubmit}
+						data-testid="submit-button"
+					>
+						Take Order
+					</Button>
 				</div>
 			</div>
 		{/if}


### PR DESCRIPTION
## Summary
- The Take Order modal now shows a connect-wallet prompt immediately when no wallet is connected, instead of waiting on quotes and rendering an empty shell.
- Quotes and the take form load only after the wallet connects, matching Deposit/Withdraw.

## Test plan
- [ ] Open Take Order while disconnected: modal shows “Connect your wallet to continue.” and a Connect button; no quote spinner or amount fields.
- [ ] Connect from the modal: quotes load and the buy/sell form appears.
- [ ] Open Take Order while already connected: form still loads as before.
- [ ] `npm run test -w @rainlanguage/webapp -- src/__tests__/TakeOrderModal.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a wallet-connection prompt in the order modal when a wallet is not connected.
  * Added Cancel and wallet connection controls before quote loading begins.
  * The Take Order button now remains visible but is disabled until wallet and form requirements are met.

* **Bug Fixes**
  * Prevented quote requests from being made while the wallet is disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->