### PR TITLE
Cap take-order MAX at the taker's wallet balance

### DIFF
--- a/crates/common/src/raindex_client/vaults.rs
+++ b/crates/common/src/raindex_client/vaults.rs
@@ -793,14 +793,38 @@ impl RaindexVault {
         preserve_js_class
     )]
     pub async fn get_owner_balance_wasm_binding(&self) -> Result<AccountBalance, RaindexError> {
-        let balance = self.get_owner_balance(self.owner).await?;
-        let decimals = self.token.decimals;
-        let float_balance = Float::from_fixed_decimal(balance, decimals)?;
-        let account_balance = AccountBalance {
-            balance: float_balance,
-            formatted_balance: float_balance.format()?,
-        };
-        Ok(account_balance)
+        self.account_balance(self.owner).await
+    }
+
+    /// Fetches the ERC20 balance of `account` for this vault's token.
+    ///
+    /// Same as [`RaindexVault::get_owner_balance_wasm_binding`], but for an
+    /// arbitrary address rather than the vault owner. Used by takers to cap a
+    /// take-order MAX against their own wallet balance.
+    ///
+    /// ## Examples
+    ///
+    /// ```javascript
+    /// const result = await vault.getAccountBalance(takerAddress);
+    /// if (result.error) {
+    ///   console.error("Error fetching balance:", result.error.readableMsg);
+    ///   return;
+    /// }
+    /// const accountBalance = result.value;
+    /// console.log("Raw balance:", accountBalance.balance);
+    /// console.log("Formatted balance:", accountBalance.formattedBalance);
+    /// ```
+    #[wasm_export(
+        js_name = "getAccountBalance",
+        return_description = "Account balance in both raw and human-readable format",
+        unchecked_return_type = "AccountBalance",
+        preserve_js_class
+    )]
+    pub async fn get_account_balance_wasm_binding(
+        &self,
+        #[wasm_export(param_description = "Account address to check balance for")] account: String,
+    ) -> Result<AccountBalance, RaindexError> {
+        self.account_balance(Address::from_str(&account)?).await
     }
 }
 impl RaindexVault {
@@ -808,6 +832,16 @@ impl RaindexVault {
         let rpcs = self.raindex_client.get_rpc_urls_for_chain(self.chain_id)?;
         let erc20 = ERC20::new(rpcs, self.token.address);
         Ok(erc20.get_account_balance(owner).await?)
+    }
+
+    async fn account_balance(&self, account: Address) -> Result<AccountBalance, RaindexError> {
+        let balance = self.get_owner_balance(account).await?;
+        let decimals = self.token.decimals;
+        let float_balance = Float::from_fixed_decimal(balance, decimals)?;
+        Ok(AccountBalance {
+            balance: float_balance,
+            formatted_balance: float_balance.format()?,
+        })
     }
 
     /// Builds the withdraw calldata for `amount`.

--- a/packages/raindex/test/js_api/raindexClient.test.ts
+++ b/packages/raindex/test/js_api/raindexClient.test.ts
@@ -2318,6 +2318,35 @@ describe("Rain Raindex JS API Package Bindgen Tests - Raindex Client", async fun
       assert.equal(res.balance.toFixedDecimal(18).value, BigInt(1000));
       assert.equal(res.formattedBalance, "1e-15");
     });
+
+    it("should fetch an arbitrary account balance from a raindex vault instance", async () => {
+      await mockServer
+        .forPost("/sg1")
+        .once()
+        .thenReply(200, JSON.stringify({ data: { vault: vault1 } }));
+      await mockServer.forPost("/rpc1").thenReply(
+        200,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result:
+            "0x00000000000000000000000000000000000000000000000000000000000003e8",
+        }),
+      );
+
+      const raindexClient = extractWasmEncodedData(
+        await RaindexClient.new([YAML]),
+      );
+      const vault = extractWasmEncodedData(
+        await raindexClient.getVault(1, CHAIN_ID_1_RAINDEX_ADDRESS, "0x0123"),
+      );
+
+      const res = extractWasmEncodedData(
+        await vault.getAccountBalance("0x9876543210987654321098765432109876543210"),
+      );
+      assert.equal(res.balance.toFixedDecimal(18).value, BigInt(1000));
+      assert.equal(res.formattedBalance, "1e-15");
+    });
   });
 
   describe("Transactions", () => {

--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -56,11 +56,16 @@ describe('TakeOrderModal', () => {
 		}
 	];
 
+	const mockGetAccountBalance = vi.fn();
+
 	const mockOrder = {
 		id: '0xorderid',
 		orderHash: '0xorderhash',
 		chainId: 1,
 		raindex: MOCK_RAINDEX_ADDRESS,
+		inputsList: {
+			items: [{ getAccountBalance: mockGetAccountBalance }]
+		},
 		getQuotes: vi.fn().mockResolvedValue({
 			value: mockQuotes,
 			error: undefined
@@ -79,6 +84,13 @@ describe('TakeOrderModal', () => {
 		vi.clearAllMocks();
 		mockOnSubmit.mockClear();
 		mockSignerAddressStore.mockSetSubscribeValue(MOCK_SIGNER_ADDRESS);
+		mockGetAccountBalance.mockResolvedValue({
+			value: {
+				balance: Float.parse('1000').value as Float,
+				formattedBalance: '1000'
+			},
+			error: undefined
+		});
 	});
 
 	it('renders take order modal correctly', async () => {
@@ -828,6 +840,84 @@ describe('TakeOrderModal', () => {
 				expect(screen.getByTestId('max-output')).toBeInTheDocument();
 				expect(screen.getByTestId('max-output')).toHaveTextContent('100');
 			});
+		});
+	});
+
+	describe('MAX amount', () => {
+		const maxQuotes = [
+			{
+				pair: {
+					pairName: 'USDC/ETH',
+					inputIndex: 0,
+					outputIndex: 0
+				},
+				blockNumber: 12345678,
+				success: true,
+				data: {
+					maxOutput: floatToHex(Float.parse('100').value as Float),
+					maxInput: floatToHex(Float.parse('50').value as Float),
+					ratio: floatToHex(Float.parse('0.5').value as Float),
+					inverseRatio: floatToHex(Float.parse('2').value as Float),
+					formattedMaxOutput: '100',
+					formattedMaxInput: '50',
+					formattedRatio: '0.5',
+					formattedInverseRatio: '2'
+				}
+			}
+		];
+
+		it('fills buy MAX with walletInput / ratio when that is below quote maxOutput', async () => {
+			mockGetAccountBalance.mockResolvedValue({
+				value: {
+					balance: Float.parse('10').value as Float,
+					formattedBalance: '10'
+				},
+				error: undefined
+			});
+			vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+				value: maxQuotes as never,
+				error: undefined
+			});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByText('MAX')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByText('MAX'));
+
+			const amountInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+			expect(amountInput.value).toBe('20');
+			expect(mockGetAccountBalance).toHaveBeenCalledWith(MOCK_SIGNER_ADDRESS);
+		});
+
+		it('fills sell MAX with the wallet input-token balance when it is below quote maxInput', async () => {
+			mockGetAccountBalance.mockResolvedValue({
+				value: {
+					balance: Float.parse('10').value as Float,
+					formattedBalance: '10'
+				},
+				error: undefined
+			});
+			vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+				value: maxQuotes as never,
+				error: undefined
+			});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('direction-sell')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByTestId('direction-sell'));
+
+			await waitFor(() => {
+				expect(screen.getByText('MAX')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByText('MAX'));
+
+			const amountInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+			expect(amountInput.value).toBe('10');
 		});
 	});
 });

--- a/packages/webapp/src/lib/components/TakeOrderModal.svelte
+++ b/packages/webapp/src/lib/components/TakeOrderModal.svelte
@@ -9,6 +9,7 @@
 	} from '@rainlanguage/ui-components';
 	import { onDestroy } from 'svelte';
 	import { appKitModal, connected, signerAddress } from '$lib/stores/wagmi';
+	import { takeOrderMaxAmount } from '$lib/services/takeOrderMaxAmount';
 	import { fade } from 'svelte/transition';
 	import {
 		Float,
@@ -127,6 +128,7 @@
 	$: selectedQuote = quotes[selectedPairIndex];
 	$: maxOutputHex = selectedQuote?.data?.maxOutput as unknown as Hex | undefined;
 	$: maxInputHex = selectedQuote?.data?.maxInput as unknown as Hex | undefined;
+	$: ratioHex = selectedQuote?.data?.ratio as unknown as Hex | undefined;
 	$: maxOutput = (() => {
 		if (!maxOutputHex) return undefined;
 		const parsed = Float.fromHex(maxOutputHex);
@@ -137,13 +139,63 @@
 		const parsed = Float.fromHex(maxInputHex);
 		return parsed.error ? undefined : (parsed.value as Float);
 	})();
+	$: ratio = (() => {
+		if (!ratioHex) return undefined;
+		const parsed = Float.fromHex(ratioHex);
+		return parsed.error ? undefined : (parsed.value as Float);
+	})();
 	$: formattedRatio = selectedQuote?.data?.formattedRatio ?? '-';
 	$: formattedMaxOutput = selectedQuote?.data?.formattedMaxOutput ?? '-';
 	$: formattedMaxInput = selectedQuote?.data?.formattedMaxInput ?? '-';
 	$: outputSymbol = selectedQuote?.pair?.pairName?.split('/')[1] ?? 'tokens';
 	$: inputSymbol = selectedQuote?.pair?.pairName?.split('/')[0] ?? 'tokens';
 
-	$: maxAmount = direction === 'buy' ? maxOutput : maxInput;
+	type VaultAccountBalance = {
+		getAccountBalance: (account: string) => Promise<{
+			value?: { balance: Float; formattedBalance: string };
+			error?: { readableMsg: string };
+		}>;
+	};
+
+	let walletInputBalance: Float | undefined = undefined;
+	let isLoadingWalletBalance = false;
+	let walletBalanceRequestId = 0;
+
+	async function loadWalletInputBalance(account: string, inputIndex: number) {
+		const requestId = ++walletBalanceRequestId;
+		isLoadingWalletBalance = true;
+		walletInputBalance = undefined;
+		try {
+			const vaults = (order.inputsList?.items ?? []) as VaultAccountBalance[];
+			const vault = vaults[inputIndex];
+			if (!vault?.getAccountBalance) return;
+			const result = await vault.getAccountBalance(account);
+			if (requestId !== walletBalanceRequestId) return;
+			if (result.error || !result.value) return;
+			walletInputBalance = result.value.balance;
+		} finally {
+			if (requestId === walletBalanceRequestId) {
+				isLoadingWalletBalance = false;
+			}
+		}
+	}
+
+	$: if (open && $signerAddress && selectedQuote) {
+		loadWalletInputBalance($signerAddress, selectedQuote.pair.inputIndex);
+	}
+
+	$: maxAmount = (() => {
+		const quoteCap = direction === 'buy' ? maxOutput : maxInput;
+		if (!quoteCap || isLoadingWalletBalance) return undefined;
+		if (!walletInputBalance || !maxOutput || !maxInput || !ratio) return quoteCap;
+		return takeOrderMaxAmount({
+			direction,
+			maxOutput,
+			maxInput,
+			ratio,
+			walletInputBalance
+		});
+	})();
 	$: formattedMaxAmount = direction === 'buy' ? formattedMaxOutput : formattedMaxInput;
 	$: amountSymbol = direction === 'buy' ? outputSymbol : inputSymbol;
 

--- a/packages/webapp/src/lib/services/takeOrderMaxAmount.test.ts
+++ b/packages/webapp/src/lib/services/takeOrderMaxAmount.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { Float } from '@rainlanguage/raindex';
+import { takeOrderMaxAmount } from './takeOrderMaxAmount';
+
+function f(value: string): Float {
+	return Float.parse(value).value as Float;
+}
+
+describe('takeOrderMaxAmount', () => {
+	it('caps sell MAX at the wallet input-token balance when it is below quote maxInput', () => {
+		const result = takeOrderMaxAmount({
+			direction: 'sell',
+			maxOutput: f('100'),
+			maxInput: f('50'),
+			ratio: f('0.5'),
+			walletInputBalance: f('10')
+		});
+		expect(result.format().value).toBe('10');
+	});
+
+	it('caps sell MAX at quote maxInput when the wallet can spend more than the order', () => {
+		const result = takeOrderMaxAmount({
+			direction: 'sell',
+			maxOutput: f('100'),
+			maxInput: f('50'),
+			ratio: f('0.5'),
+			walletInputBalance: f('80')
+		});
+		expect(result.format().value).toBe('50');
+	});
+
+	it('caps buy MAX at walletInput / ratio when that is below quote maxOutput', () => {
+		const result = takeOrderMaxAmount({
+			direction: 'buy',
+			maxOutput: f('100'),
+			maxInput: f('50'),
+			ratio: f('0.5'),
+			walletInputBalance: f('10')
+		});
+		expect(result.format().value).toBe('20');
+	});
+
+	it('caps buy MAX at quote maxOutput when the wallet can afford the full order', () => {
+		const result = takeOrderMaxAmount({
+			direction: 'buy',
+			maxOutput: f('100'),
+			maxInput: f('50'),
+			ratio: f('0.5'),
+			walletInputBalance: f('80')
+		});
+		expect(result.format().value).toBe('100');
+	});
+});

--- a/packages/webapp/src/lib/services/takeOrderMaxAmount.ts
+++ b/packages/webapp/src/lib/services/takeOrderMaxAmount.ts
@@ -1,0 +1,31 @@
+import { Float } from '@rainlanguage/raindex';
+
+export type TakeOrderDirection = 'buy' | 'sell';
+
+export function minFloat(a: Float, b: Float): Float {
+	const cmp = a.lte(b);
+	if (cmp.error) return a;
+	return cmp.value ? a : b;
+}
+
+/**
+ * MAX amount for the take-order field, in the field's units.
+ *
+ * Buy amounts are output tokens, so the wallet cap is `walletInput / ratio`.
+ * Sell amounts are input tokens, so the wallet cap is the input-token balance.
+ */
+export function takeOrderMaxAmount(args: {
+	direction: TakeOrderDirection;
+	maxOutput: Float;
+	maxInput: Float;
+	ratio: Float;
+	walletInputBalance: Float;
+}): Float {
+	if (args.direction === 'sell') {
+		return minFloat(args.maxInput, args.walletInputBalance);
+	}
+
+	const affordableOutput = args.walletInputBalance.div(args.ratio);
+	if (affordableOutput.error) return args.maxOutput;
+	return minFloat(args.maxOutput, affordableOutput.value as Float);
+}


### PR DESCRIPTION
## Summary
- Take-order MAX is now `min(quote cap, what this wallet can pay)` in the amount field's units.
- Buy: `min(maxOutput, walletInput / ratio)`. Sell: `min(maxInput, walletInput)`.
- Adds `RaindexVault.getAccountBalance(account)` so the modal can read the connected wallet's input-token balance.

Stacked on #2858 (connect-first). Merge that first.

## Test plan
- [ ] Connect wallet, open Take Order on a buy pair where wallet input-token balance < quote size. MAX fills `walletBalance / currentPrice`, not full maxOutput.
- [ ] Switch to Sell. MAX fills `min(maxInput, wallet input-token balance)`.
- [ ] Wallet with more than the order can fill: MAX still equals quote maxOutput / maxInput.
- [ ] `npm run test -w @rainlanguage/webapp -- src/__tests__/TakeOrderModal.test.ts src/lib/services/takeOrderMaxAmount.test.ts`


Made with [Cursor](https://cursor.com)