### PR TITLE
Add current-quote Max Price shortcut with 0.5% buffer

### DIFF
--- a/packages/webapp/src/__tests__/TakeOrderModal.test.ts
+++ b/packages/webapp/src/__tests__/TakeOrderModal.test.ts
@@ -920,4 +920,140 @@ describe('TakeOrderModal', () => {
 			expect(amountInput.value).toBe('10');
 		});
 	});
+
+	describe('max price current-quote shortcut', () => {
+		const priceQuotes = [
+			{
+				pair: {
+					pairName: 'USDC/ETH',
+					inputIndex: 0,
+					outputIndex: 0
+				},
+				blockNumber: 12345678,
+				success: true,
+				data: {
+					maxOutput: floatToHex(Float.parse('100').value as Float),
+					maxInput: floatToHex(Float.parse('50').value as Float),
+					ratio: floatToHex(Float.parse('100').value as Float),
+					inverseRatio: floatToHex(Float.parse('0.01').value as Float),
+					formattedMaxOutput: '100',
+					formattedMaxInput: '50',
+					formattedRatio: '100',
+					formattedInverseRatio: '0.01'
+				}
+			}
+		];
+
+		it('fills Max Price with the current quote plus a 0.5% buffer', async () => {
+			vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+				value: priceQuotes as never,
+				error: undefined
+			});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('price-cap-current-button')).toBeInTheDocument();
+			});
+			expect(screen.getByTestId('price-cap-current-button')).toHaveTextContent('CURRENT +0.5%');
+
+			await fireEvent.click(screen.getByTestId('price-cap-current-button'));
+
+			const priceCapInput = screen.getByTestId('price-cap-input') as HTMLInputElement;
+			expect(priceCapInput.value).toBe('100.5');
+			expect(screen.getByTestId('price-cap-buffer-hint')).toHaveTextContent(
+				'Includes a 0.5% buffer above the current quote so the next block can still fill.'
+			);
+		});
+
+		it('does not reject CURRENT +0.5% when the buffered quote has more than 67 decimals', async () => {
+			const highPrecisionQuotes = [
+				{
+					...priceQuotes[0],
+					data: {
+						...priceQuotes[0].data,
+						ratio: floatToHex(
+							Float.parse('0.011068446678066134741211935').value as Float
+						),
+						formattedRatio: '0.011068446678066134741211935'
+					}
+				}
+			];
+			vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+				value: highPrecisionQuotes as never,
+				error: undefined
+			});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('price-cap-current-button')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByTestId('price-cap-current-button'));
+
+			const priceCapInput = screen.getByTestId('price-cap-input') as HTMLInputElement;
+			expect(priceCapInput.value).not.toBe('');
+			expect(screen.queryByTestId('price-cap-error')).not.toBeInTheDocument();
+		});
+
+		it('keeps the filled cap when the quote refreshes to a new price', async () => {
+			const laterQuotes = [
+				{
+					...priceQuotes[0],
+					data: {
+						...priceQuotes[0].data,
+						ratio: floatToHex(Float.parse('200').value as Float),
+						formattedRatio: '200'
+					}
+				}
+			];
+
+			vi.mocked(mockOrder.getQuotes)
+				.mockResolvedValueOnce({
+					value: priceQuotes as never,
+					error: undefined
+				})
+				.mockResolvedValueOnce({
+					value: laterQuotes as never,
+					error: undefined
+				});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('price-cap-current-button')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByTestId('price-cap-current-button'));
+
+			const priceCapInput = screen.getByTestId('price-cap-input') as HTMLInputElement;
+			expect(priceCapInput.value).toBe('100.5');
+
+			await fireEvent.click(screen.getByTestId('refresh-button'));
+
+			await waitFor(() => {
+				expect(screen.getByTestId('current-price')).toHaveTextContent('200');
+			});
+			expect(priceCapInput.value).toBe('100.5');
+		});
+
+		it('hides the buffer hint when the user edits Max Price', async () => {
+			vi.mocked(mockOrder.getQuotes).mockResolvedValue({
+				value: priceQuotes as never,
+				error: undefined
+			});
+
+			render(TakeOrderModal, defaultProps);
+
+			await waitFor(() => {
+				expect(screen.getByTestId('price-cap-current-button')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByTestId('price-cap-current-button'));
+			expect(screen.getByTestId('price-cap-buffer-hint')).toBeInTheDocument();
+
+			const priceCapInput = screen.getByTestId('price-cap-input');
+			await fireEvent.input(priceCapInput, { target: { value: '101' } });
+
+			expect(screen.queryByTestId('price-cap-buffer-hint')).not.toBeInTheDocument();
+		});
+	});
 });

--- a/packages/webapp/src/lib/components/TakeOrderModal.svelte
+++ b/packages/webapp/src/lib/components/TakeOrderModal.svelte
@@ -10,6 +10,10 @@
 	import { onDestroy } from 'svelte';
 	import { appKitModal, connected, signerAddress } from '$lib/stores/wagmi';
 	import { takeOrderMaxAmount } from '$lib/services/takeOrderMaxAmount';
+	import {
+		TAKE_ORDER_PRICE_CAP_BUFFER_LABEL,
+		formatBufferedPriceCap
+	} from '$lib/services/takeOrderPriceCap';
 	import { fade } from 'svelte/transition';
 	import {
 		Float,
@@ -36,6 +40,7 @@
 	let direction: Direction = 'buy';
 	let exact: boolean = false;
 	let priceCap: string = '';
+	let priceCapFromCurrentQuote = false;
 	let errorMessage = '';
 	let isLoadingQuotes = false;
 	let isFetchingQuotes = false;
@@ -120,6 +125,7 @@
 		direction = 'buy';
 		exact = false;
 		priceCap = '';
+		priceCapFromCurrentQuote = false;
 		errorMessage = '';
 		estimateResult = null;
 		selectedPairIndex = 0;
@@ -244,6 +250,18 @@
 	}
 
 	$: priceCapDecimalsError = validateAmount(priceCap).errorMessage;
+
+	function fillBufferedCurrentPrice() {
+		if (!ratio) return;
+		const formatted = formatBufferedPriceCap(ratio);
+		if (!formatted) return;
+		priceCap = formatted;
+		priceCapFromCurrentQuote = true;
+	}
+
+	function handlePriceCapInput() {
+		priceCapFromCurrentQuote = false;
+	}
 
 	$: effectivePriceCap = (() => {
 		if (priceCap && priceCap.trim() !== '') {
@@ -455,14 +473,37 @@
 							- {inputSymbol} per {outputSymbol}
 						</span>
 					</Label>
-					<input
-						id="price-cap"
-						type="text"
-						class="block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
-						placeholder={`Enter max price in ${inputSymbol} per ${outputSymbol}`}
-						bind:value={priceCap}
-						data-testid="price-cap-input"
-					/>
+					<div class="relative">
+						<input
+							id="price-cap"
+							type="text"
+							class="block w-full rounded-lg border-gray-300 bg-gray-50 p-2.5 pr-32 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-500 dark:bg-gray-600 dark:text-white dark:placeholder-gray-400 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+							placeholder={`Enter max price in ${inputSymbol} per ${outputSymbol}`}
+							bind:value={priceCap}
+							on:input={handlePriceCapInput}
+							data-testid="price-cap-input"
+						/>
+						{#if ratio}
+							<div class="absolute right-2 top-0 flex h-10 items-center">
+								<Button
+									color="blue"
+									class="px-2 py-1"
+									size="xs"
+									pill
+									on:click={fillBufferedCurrentPrice}
+									data-testid="price-cap-current-button"
+								>
+									CURRENT +{TAKE_ORDER_PRICE_CAP_BUFFER_LABEL}
+								</Button>
+							</div>
+						{/if}
+					</div>
+					{#if priceCapFromCurrentQuote}
+						<p class="mt-1 text-xs text-gray-500 dark:text-gray-400" data-testid="price-cap-buffer-hint">
+							Includes a {TAKE_ORDER_PRICE_CAP_BUFFER_LABEL} buffer above the current quote so the next
+							block can still fill.
+						</p>
+					{/if}
 					{#if priceCapDecimalsError}
 						<p class="mt-1 text-sm text-red-500" data-testid="price-cap-error">
 							{priceCapDecimalsError}

--- a/packages/webapp/src/lib/services/takeOrderPriceCap.test.ts
+++ b/packages/webapp/src/lib/services/takeOrderPriceCap.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { Float } from '@rainlanguage/raindex';
+import {
+	TAKE_ORDER_PRICE_CAP_BUFFER_LABEL,
+	MAX_PRICE_CAP_DECIMALS,
+	bufferedPriceCap,
+	formatBufferedPriceCap,
+	limitDecimalPlaces
+} from './takeOrderPriceCap';
+
+function f(value: string): Float {
+	return Float.parse(value).value as Float;
+}
+
+function decimalCount(value: string): number {
+	const dot = value.indexOf('.');
+	return dot === -1 ? 0 : value.length - dot - 1;
+}
+
+describe('bufferedPriceCap', () => {
+	it('exposes a 0.5% buffer label', () => {
+		expect(TAKE_ORDER_PRICE_CAP_BUFFER_LABEL).toBe('0.5%');
+	});
+
+	it('raises the current quote by 0.5%', () => {
+		const result = bufferedPriceCap(f('100'));
+		expect(result?.format().value).toBe('100.5');
+	});
+
+	it('raises a non-round quote by 0.5%', () => {
+		const result = bufferedPriceCap(f('200'));
+		expect(result?.format().value).toBe('201');
+	});
+});
+
+describe('limitDecimalPlaces', () => {
+	it('leaves values within the parser limit unchanged', () => {
+		expect(limitDecimalPlaces('100.5', MAX_PRICE_CAP_DECIMALS)).toBe('100.5');
+	});
+
+	it('truncates a CURRENT +0.5% snapshot that exceeds 67 decimals', () => {
+		const tooLong =
+			'0.011121324352043270230379406670855011893399508723917687482222187121207';
+		expect(decimalCount(tooLong)).toBeGreaterThan(MAX_PRICE_CAP_DECIMALS);
+
+		const limited = limitDecimalPlaces(tooLong, MAX_PRICE_CAP_DECIMALS);
+		expect(decimalCount(limited)).toBe(MAX_PRICE_CAP_DECIMALS);
+		expect(limited).toBe(
+			'0.0111213243520432702303794066708550118933995087239176874822221871212'
+		);
+	});
+});
+
+describe('formatBufferedPriceCap', () => {
+	it('formats a round quote plus 0.5% without extra decimals', () => {
+		expect(formatBufferedPriceCap(f('100'))).toBe('100.5');
+	});
+
+	it('always returns a string with at most 67 decimal places for any finite quote', () => {
+		const quote = f('0.011068446678066134741211935');
+		const formatted = formatBufferedPriceCap(quote);
+		expect(formatted).toBeDefined();
+		expect(decimalCount(formatted as string)).toBeLessThanOrEqual(MAX_PRICE_CAP_DECIMALS);
+	});
+});

--- a/packages/webapp/src/lib/services/takeOrderPriceCap.ts
+++ b/packages/webapp/src/lib/services/takeOrderPriceCap.ts
@@ -1,0 +1,50 @@
+import { Float } from '@rainlanguage/raindex';
+
+/** Multiplier for a 0.5% ceiling above the current quote ratio. */
+const TAKE_ORDER_PRICE_CAP_BUFFER_MULTIPLIER = '1.005';
+
+/**
+ * Must match `@rainlanguage/ui-components` `MAX_DECIMALS`. The Max Price
+ * field rejects more fractional digits than this.
+ */
+export const MAX_PRICE_CAP_DECIMALS = 67;
+
+export const TAKE_ORDER_PRICE_CAP_BUFFER_LABEL = '0.5%';
+
+/**
+ * Snapshot cap for Max Price: current quote ratio plus a 0.5% buffer so a
+ * slightly worse next-block print can still land.
+ */
+export function bufferedPriceCap(currentRatio: Float): Float | undefined {
+	const multiplier = Float.parse(TAKE_ORDER_PRICE_CAP_BUFFER_MULTIPLIER);
+	if (multiplier.error) return undefined;
+	const result = currentRatio.mul(multiplier.value as Float);
+	if (result.error) return undefined;
+	return result.value as Float;
+}
+
+/**
+ * Formats {@link bufferedPriceCap} for the Max Price text field.
+ *
+ * `Float.format()` can emit more fractional digits than the client-side
+ * parser accepts (67). Truncate so CURRENT +0.5% never fails decimal
+ * validation. The dropped digits are far smaller than the 0.5% buffer.
+ */
+export function formatBufferedPriceCap(currentRatio: Float): string | undefined {
+	const buffered = bufferedPriceCap(currentRatio);
+	if (!buffered) return undefined;
+	const formatted = buffered.format();
+	if (formatted.error || typeof formatted.value !== 'string') return undefined;
+	return limitDecimalPlaces(formatted.value, MAX_PRICE_CAP_DECIMALS);
+}
+
+export function limitDecimalPlaces(value: string, maxDecimals: number): string {
+	const sign = value.startsWith('-') ? '-' : '';
+	const unsigned = sign ? value.slice(1) : value;
+	const dot = unsigned.indexOf('.');
+	if (dot === -1) return value;
+
+	const fractionalPart = unsigned.slice(dot + 1);
+	if (fractionalPart.length <= maxDecimals) return value;
+	return `${sign}${unsigned.slice(0, dot + 1 + maxDecimals)}`;
+}


### PR DESCRIPTION
## Summary
- Max Price gets a `CURRENT +0.5%` shortcut that snapshots `currentQuote × 1.005` into the field.
- A hint explains the buffer so the next block can still fill. Quote refresh does not overwrite the filled cap; clicking the shortcut again re-snapshots. Editing the field hides the hint.

Stacked on #2859. Merge #2858, then #2859, then this.

## Test plan
- [x] Open Take Order while connected. Max Price shows `CURRENT +0.5%`.
- [x] Click it: field fills current price × 1.005 and the buffer hint appears.
- [x] Wait for / click quote refresh: Max Price stays put while Current Price updates.
- [x] Click the shortcut again: field updates to the new quote × 1.005.
- [x] Edit Max Price by hand: buffer hint disappears.
- [x] `npm run test -w @rainlanguage/webapp -- src/lib/services/takeOrderPriceCap.test.ts src/__tests__/TakeOrderModal.test.ts`


Made with [Cursor](https://cursor.com)