### PR TITLE
Pin the registry to the Ormi subgraph URLs

### DIFF
--- a/crates/rest_api/src/config.rs
+++ b/crates/rest_api/src/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-pub const DEFAULT_REGISTRY_URL: &str = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/de1d6990052d5003cadf4550fed4a2bfdf9560ff/registry";
+pub const DEFAULT_REGISTRY_URL: &str = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/3248448d54c29068b0bca3e5d2acca1440face43/registry";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {

--- a/packages/raindex/README.md
+++ b/packages/raindex/README.md
@@ -85,7 +85,7 @@ networks:
     currency: ETH
 
 metaboards:
-  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/metadata-base/2025-07-06-594f/gn
+  base: https://subgraph.api.ormilabs.com/api/public/9f4fc2fa-4a15-44f7-a7c1-66fdaa518a71/subgraphs/metadata-base/prod/gn
 
 subgraphs:
   base: https://example.com/subgraph

--- a/packages/webapp/src/lib/constants.ts
+++ b/packages/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const REGISTRY_URL =
-  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/de1d6990052d5003cadf4550fed4a2bfdf9560ff/registry";
+  "https://raw.githubusercontent.com/rainlanguage/rain.strategies/3248448d54c29068b0bca3e5d2acca1440face43/registry";


### PR DESCRIPTION
## Summary
Bumps the pinned `rain.strategies` registry commit to `3248448` (rainlanguage/rain.strategies#129), whose `settings.yaml` points the Base subgraph and metaboard at the Ormi tagged endpoints (`raindex-base/prod`, `metadata-base/prod`) instead of Goldsky. Same deployments, rebuilt from the same source on Ormi.

- `packages/webapp/src/lib/constants.ts`: registry pin
- `crates/rest_api/src/config.rs`: `DEFAULT_REGISTRY_URL` pin
- `packages/raindex/README.md`: example metaboard URL

The registry commit exists on the `ormi-subgraph-urls` branch of rain.strategies; raw.githubusercontent serves it now, and the previous pins were branch commits too. Merge after the Ormi Base subgraphs report fully synced, then ship a webapp build so raindex.finance stops querying Goldsky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the default strategy registry reference to a newer pinned version.
  - Refreshed the web app to use the same updated registry version.
  - Updated the example configuration to use the current hosted subgraph endpoint.

- **Documentation**
  - Updated the sample configuration endpoint to reflect the current service location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->