### PR TITLE
Pin the v4 settings to the Ormi Flare subgraph

### DIFF
--- a/packages/webapp/src/routes/+layout.ts
+++ b/packages/webapp/src/routes/+layout.ts
@@ -11,7 +11,7 @@ export interface LayoutData {
 }
 
 const REMOTE_SETTINGS_URL =
-	'https://raw.githubusercontent.com/rainlanguage/rain.strategies/ee6209e0012a8ef95b6dd4b540cba07b475a6a75/settings.yaml';
+	'https://raw.githubusercontent.com/rainlanguage/rain.strategies/19c00deb27fdbd61c76e0d01388c83c7801e4bd4/settings.yaml';
 
 export const load: LayoutLoad<LayoutData> = async ({ fetch }) => {
 	let errorMessage: string | undefined;


### PR DESCRIPTION
## Summary
Bumps the settings pin in the v4 webapp to rain.strategies `19c00de` (rainlanguage/rain.strategies#130), which points the Flare orderbook subgraph at Ormi (`ob4-flare/prod`, same code and contract as the deleted Goldsky `ob4-flare/2024-12-13-9dc7`, fully synced).

raindex.finance is deployed from this branch by the Vercel production workflow on merge. Flare orders and vaults come back; the other chains stay blank until their Ormi subgraphs exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)