### PR TITLE
Reuse the HTTP client for subgraph queries

### DIFF
--- a/crates/subgraph/src/cynic_client.rs
+++ b/crates/subgraph/src/cynic_client.rs
@@ -2,8 +2,15 @@ use cynic::{
     serde::{Deserialize, Serialize},
     GraphQlError, GraphQlResponse, QueryBuilder, QueryFragment,
 };
-use reqwest::Url;
+use once_cell::sync::OnceCell;
+use reqwest::{Client, Url};
 use thiserror::Error;
+
+static CYNIC_HTTP_CLIENT: OnceCell<Client> = OnceCell::new();
+
+fn shared_http_client() -> Result<&'static Client, reqwest::Error> {
+    CYNIC_HTTP_CLIENT.get_or_try_init(|| Client::builder().build())
+}
 
 #[derive(Error, Debug)]
 pub enum CynicClientError {
@@ -26,7 +33,7 @@ pub trait CynicClient {
     ) -> Result<R, CynicClientError> {
         let request_body = R::build(variables);
 
-        let response = reqwest::Client::new()
+        let response = shared_http_client()?
             .post(self.get_base_url().clone())
             .json(&request_body)
             .send()
@@ -48,5 +55,18 @@ pub trait CynicClient {
             Some(errors) => Err(CynicClientError::GraphqlError(errors)),
             None => response_deserialized.data.ok_or(CynicClientError::Empty),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reuses_the_process_wide_http_client() {
+        let first = shared_http_client().expect("build shared HTTP client");
+        let second = shared_http_client().expect("reuse shared HTTP client");
+
+        assert!(std::ptr::eq(first, second));
     }
 }


### PR DESCRIPTION
## Summary
- reuse one process-wide HTTP client for Cynic subgraph queries
- preserve connection pooling and avoid rebuilding TLS root certificates for every query
- initialize the client fallibly so resource exhaustion returns an error instead of panicking

This complements ST0x REST API capacity controls in ST0x-Technology/st0x.rest.api#184 by reducing the per-query resource cost in the shared Raindex client.

## Test plan
- [x] `nix develop -c cargo fmt --all -- --check`
- [x] `nix develop -c cargo test -p raindex_subgraph_client`
- [x] `nix develop -c cargo clippy -p raindex_subgraph_client --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved request handling by reusing a shared HTTP client across queries.
  * Reduced repeated client initialization during application use.

* **Tests**
  * Added coverage verifying consistent reuse of the shared HTTP client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->