### PR TITLE
Bump rain-deploy to 0.1.8: Robinhood Chain (4663) + BNB Smart Chain (56)

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -19,6 +19,21 @@ on:
           - arb-generic-pool-order-taker
           - arb-route-processor-order-taker
           - arb-generic-pool-flash-borrower
+          # Frozen releases: what a newly supported network needs, so the
+          # addresses every consumer pins land there (the bare keys above
+          # deploy current source, which has moved since these were cut).
+          - raindex@0_1_14
+          - raindex@0_1_15
+          - subparser@0_1_14
+          - subparser@0_1_15
+          - route-processor@0_1_14
+          - route-processor@0_1_15
+          - arb-generic-pool-order-taker@0_1_14
+          - arb-generic-pool-order-taker@0_1_15
+          - arb-route-processor-order-taker@0_1_14
+          - arb-route-processor-order-taker@0_1_15
+          - arb-generic-pool-flash-borrower@0_1_14
+          - arb-generic-pool-flash-borrower@0_1_15
       script:
         description: >-
           Forge script target to run. The default deploys the selected suite; script/DescribeSubParser.sol:DescribeSubParser emits the sub-parser's described-by meta on the network named by `network` (suite is ignored there).

--- a/foundry.toml
+++ b/foundry.toml
@@ -59,7 +59,7 @@ fs_permissions = [
 remappings = [
   # Custom remap so @openzeppelin packages' own internal imports resolve.
   "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.6.1/",
-  # `rain-deploy` 0.1.7, and the `rain-sol-codegen` 0.1.36 it is built on,
+  # `rain-deploy` 0.1.8, and the `rain-sol-codegen` 0.1.36 it is built on,
   # spell forge-std as `forge-std-1.16.2/`; `rainlang` 0.1.5 and
   # `rain-interpreter-interface` 0.1.0 still spell it `forge-std-1.16.1/`.
   # Soldeer installs ONE version per package name, so the older prefix is
@@ -70,7 +70,7 @@ remappings = [
   # These live here rather than in `remappings.txt` because `forge soldeer
   # install` owns that file and regenerates it from the installed set.
   "forge-std-1.16.1/=dependencies/forge-std-1.16.2/",
-  # Same, for `rain-sol-codegen`. `rain-deploy` 0.1.7 needs 0.1.36, while
+  # Same, for `rain-sol-codegen`. `rain-deploy` 0.1.8 needs 0.1.36, while
   # `rainlang` 0.1.5 and `rain-interpreter-interface` 0.1.0 import the
   # `IParserToolingV1` / `ISubParserToolingV1` / `IOpcodeToolingV1` /
   # `IIntegrityToolingV1` interfaces under the `rain-sol-codegen-0.1.0/`
@@ -81,9 +81,9 @@ remappings = [
   # Same, for `rain-deploy`. `rainlang` 0.1.5's committed test abstracts
   # (`RainlangExpressionDeployerDeploymentTest`, reached from this repo's
   # tests) import `rain-deploy-0.1.2/src/lib/LibRainDeploy.sol` for
-  # `etchZoltuFactory`/`deployZoltu`, which are unchanged in 0.1.7. Test-only:
+  # `etchZoltuFactory`/`deployZoltu`, which are unchanged in 0.1.8. Test-only:
   # nothing under `src/` reaches rain-deploy, so no contract bytecode moves.
-  "rain-deploy-0.1.2/=dependencies/rain-deploy-0.1.7/",
+  "rain-deploy-0.1.2/=dependencies/rain-deploy-0.1.8/",
   # Same, for `rain-metadata`. `rainlang` 0.1.5's `BaseRainlangSubParser`
   # imports `IDescribedByMetaV1` under the `rain-metadata-0.1.0/` prefix, and
   # that interface file is byte-identical in 0.1.0 and 0.1.7, so the older
@@ -112,7 +112,7 @@ rain-sol-codegen = "0.1.36"
 rain-solmem = "0.1.3"
 rain-math-float = "0.1.1"
 rain-tofu-erc20-decimals = "0.1.1"
-rain-deploy = "0.1.7"
+rain-deploy = "0.1.8"
 rain-lib-typecast = "0.1.0"
 rain-lib-hash = "0.1.0"
 rain-math-binary = "0.1.1"
@@ -132,6 +132,8 @@ base_sepolia = "${BASE_SEPOLIA_RPC_URL}"
 ethereum = "${ETHEREUM_RPC_URL}"
 flare = "${FLARE_RPC_URL}"
 hyperevm = "${HYPEREVM_RPC_URL}"
+robinhood = "${ROBINHOOD_RPC_URL}"
+bsc = "${BSC_RPC_URL}"
 polygon = "${POLYGON_RPC_URL}"
 
 [etherscan]
@@ -141,4 +143,11 @@ base_sepolia = { key = "${CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY}" }
 ethereum = { key = "${CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY}", chain = 1 }
 flare = { key = "${CI_DEPLOY_FLARE_ETHERSCAN_API_KEY}" }
 hyperevm = { key = "${CI_DEPLOY_HYPEREVM_ETHERSCAN_API_KEY}", chain = 999 }
+# Robinhood Chain (4663) is not indexed by Etherscan V2. Its Blockscout speaks
+# the Etherscan API, so the entry points there (the key is ignored). That
+# explorer has rejected non-browser clients, so if `--verify` fails there,
+# verify afterwards through Sourcify: `forge verify-contract --verifier
+# sourcify --chain 4663 ...`.
+robinhood = { key = "${CI_DEPLOY_ROBINHOOD_ETHERSCAN_API_KEY}", chain = 4663, url = "https://robinhoodchain.blockscout.com/api" }
+bsc = { key = "${CI_DEPLOY_BSC_ETHERSCAN_API_KEY}", chain = 56 }
 polygon = { key = "${CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY}" }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,6 @@
 @openzeppelin-contracts-5.6.1/=dependencies/@openzeppelin-contracts-5.6.1/
 forge-std-1.16.2/=dependencies/forge-std-1.16.2/
-rain-deploy-0.1.7/=dependencies/rain-deploy-0.1.7/
+rain-deploy-0.1.8/=dependencies/rain-deploy-0.1.8/
 rain-interpreter-interface-0.1.0/=dependencies/rain-interpreter-interface-0.1.0/
 rain-intorastring-0.1.0/=dependencies/rain-intorastring-0.1.0/
 rain-lib-hash-0.1.0/=dependencies/rain-lib-hash-0.1.0/

--- a/script/Build.sol
+++ b/script/Build.sol
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {BuildScript} from "rain-deploy-0.1.7/src/abstract/BuildScript.sol";
-import {LibRainDeploySnapshot} from "rain-deploy-0.1.7/src/lib/LibRainDeploySnapshot.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.7/src/lib/LibRainDeploy.sol";
+import {BuildScript} from "rain-deploy-0.1.8/src/abstract/BuildScript.sol";
+import {LibRainDeploySnapshot} from "rain-deploy-0.1.8/src/lib/LibRainDeploySnapshot.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.8/src/lib/LibRainDeploy.sol";
 import {LibCodeGen} from "rain-sol-codegen-0.1.36/src/lib/LibCodeGen.sol";
 import {LibFs} from "rain-sol-codegen-0.1.36/src/lib/LibFs.sol";
 import {LibGenParseMeta} from "rain-interpreter-interface-0.1.0/src/lib/codegen/LibGenParseMeta.sol";

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {RainDeployBroadcast} from "rain-deploy-0.1.7/src/abstract/RainDeployBroadcast.sol";
+import {RainDeployBroadcast} from "rain-deploy-0.1.8/src/abstract/RainDeployBroadcast.sol";
 import {RaindexDeploySuites} from "../src/abstract/RaindexDeploySuites.sol";
 
 /// @title Deploy

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -14,10 +14,10 @@ integrity = "5fb4325b60d7d4194bd0481e2f94398cf1d9c6561dd12a66fb2748ef4a68205f"
 
 [[dependencies]]
 name = "rain-deploy"
-version = "0.1.7"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_7_19-08-2026_05:57:12_rain.zip"
-checksum = "d0e868184ad16fc6abb704bb1dddab57ebf2beb042529690e030568f5c81a9b3"
-integrity = "e51da6f2b3a0f427a0aac5d7714bed2027f5cf0f39b31f0692e9623ceeaa47f2"
+version = "0.1.8"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_8_10-09-2026_14:32:04_rain.zip"
+checksum = "506d4b9acea5a06bd6d49442caa17075fd40a70c9662d26fbc6e79339e6e1dc4"
+integrity = "44375e425fed5e640711e47c9256aff7643566454870d940f9e831b502d940e5"
 
 [[dependencies]]
 name = "rain-interpreter-interface"

--- a/src/abstract/RainDeploySuitesBase.sol
+++ b/src/abstract/RainDeploySuitesBase.sol
@@ -12,4 +12,4 @@ import {
     DeployCandidate,
     DeploySuite,
     RainDeploySuitesBase
-} from "rain-deploy-0.1.7/src/abstract/RainDeploySuitesBase.sol";
+} from "rain-deploy-0.1.8/src/abstract/RainDeploySuitesBase.sol";

--- a/test/abstract/RaindexDeployChain.t.sol
+++ b/test/abstract/RaindexDeployChain.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {RainDeployVerifyChain} from "rain-deploy-0.1.7/src/abstract/RainDeployVerifyChain.sol";
+import {RainDeployVerifyChain} from "rain-deploy-0.1.8/src/abstract/RainDeployVerifyChain.sol";
 import {RaindexDeploySuites} from "../../src/abstract/RaindexDeploySuites.sol";
 
 /// @title RaindexDeployChainTest

--- a/test/abstract/RaindexDeploySnapshot.t.sol
+++ b/test/abstract/RaindexDeploySnapshot.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {RainDeployVerifySnapshot} from "rain-deploy-0.1.7/src/abstract/RainDeployVerifySnapshot.sol";
+import {RainDeployVerifySnapshot} from "rain-deploy-0.1.8/src/abstract/RainDeployVerifySnapshot.sol";
 import {RaindexDeploySuites} from "../../src/abstract/RaindexDeploySuites.sol";
 
 /// @title RaindexDeploySnapshotTest


### PR DESCRIPTION
rain-deploy 0.1.8 adds Robinhood Chain (4663) and BNB Smart Chain (56) to `LibRainDeploy.supportedNetworks()` ([rain.deploy#161](https://github.com/rainlanguage/rain.deploy/pull/161), released as [#162](https://github.com/rainlanguage/rain.deploy/pull/162)). This bump takes it, adds the two `[rpc_endpoints]` + `[etherscan]` rows the inherited `RainDeployVerifySnapshot` test requires (Robinhood Chain via its Blockscout; BscScan is Etherscan V2), updates the alias-remapping comments, and moves the import prefixes and lock. No contract bytecode changes.

**Dispatcher change.** `manual-sol-artifacts` gains the frozen release keys (`…@0_1_14` / `…@0_1_15`, which share addresses) next to the rolling candidates. The inherited liveness test requires every *released* suite on every supported network, and current source has drifted since those releases, so a candidate dispatch would put new addresses on the new chains while every consumer pins the released ones — the canonical RaindexV6 `0x37FC0EFec…` above all.

**Merge gate.** CI's liveness test is red until the six released suites are dispatched to 4663 and 56 **from this branch** (the branch carries the new network list; `main` does not), and `raindex@0_1_15` needs its dependencies live there first: log tables (rain.math.float.deploy#25), TOFU (rain.tofu.erc20-decimals.deploy#7), MetaBoard (rain.metadata.deploy#12). Sequence: deps → dispatch six suites → re-run CI → merge.

Linear: [RAI-2291](https://linear.app/makeitrain/issue/RAI-2291) / [RAI-2312](https://linear.app/makeitrain/issue/RAI-2312).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiqQdxokJ4edjAFyAkN9G3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for frozen Solidity artifact suites `0.1.14` and `0.1.15`.
  * Added deployment and verification configuration for Robinhood Chain and BNB Smart Chain.
* **Improvements**
  * Updated deployment tooling compatibility to the latest supported release.
  * Clarified distinctions between frozen artifact deployments and deployments built from current source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->