### PR TITLE
subgraph: bind DecimalFloat on Robinhood Chain

### DIFF
--- a/subgraph/src/float.ts
+++ b/subgraph/src/float.ts
@@ -27,6 +27,8 @@ export function getDecimalFloatAddress(): Address {
     return Address.fromString("0x83e4c7732e715b5E7310796A4A2a21d89f3FB59A");
   } else if (network == "mainnet") {
     return Address.fromString("0x83e4c7732e715b5E7310796A4A2a21d89f3FB59A");
+  } else if (network == "robinhood") {
+    return Address.fromString("0x2F665EcE3345bF09197DAd22A50dFB623BD310A7");
   }
 
   return FALLBACK_DECIMAL_FLOAT_ADDRESS;


### PR DESCRIPTION
## The bug

The Robinhood subgraph deployed today is not lagging, it is **dead**. It aborted on the first Raindex event ever emitted on chain 4663 — a 20 USDG deposit at block 60,339,226:

```
Mapping aborted ... Call reverted, probably because an 'assert' or 'require' in the
contract failed ... in handler 'handleDeposit' at block #60339226
```

`getDecimalFloatAddress()` in `subgraph/src/float.ts` picks the contract from a hardcoded `if/else` over `dataSource.network()`: flare, base, bsc, arbitrum-one, matic, linea, mainnet. Robinhood matches none, so it falls through to `FALLBACK_DECIMAL_FLOAT_ADDRESS` = `0x…0001`. `eth_getCode` for that address on 4663 returns `0x`. Every `DecimalFloat` call therefore reverts, and since every numeric path goes through `getCalculator()`, the first event kills the subgraph.

## The fix

DecimalFloat **is** deployed on Robinhood Chain, at Base's address:

| | bytes |
|---|---|
| `0x2F665EcE3345bF09197DAd22A50dFB623BD310A7` on 4663 | 36,335 |
| the same address on Base | 36,335 |

And the exact call that aborted succeeds against it: `fromFixedDecimalLossless(20000000, 6)` → `0xfffffffa00000000000000000000000000000000000000000000000001312d00` (USDG is 6 dp, the deposit was 20 USDG).

## Which network string

This branch keys on **`robinhood`**, the network name an Ormi build carries. A Goldsky deployment renders the manifest as `robinhood-mainnet` (the `networks.json` key in #2866) and would still fall through. Adding that string to the same branch is a one-word change and fixes that deployment too — left out here deliberately.

## Two things for whoever redeploys

- **A fixed deploy is a new deployment, not a resume.** A deterministically failed graph-node subgraph does not restart. Reindexing is cheap here: about 790k blocks carrying two Raindex events in total.
- **This PR does not touch `networks.json`.** `subgraph-deploy` loops every key in that file, so adding one here would mint another hosted subgraph on the next dispatch.

## Worth noting beyond this chain

The failure shape matters more than the missing address: an unknown network returns a dead address rather than failing the build, so the first symptom is a subgraph that indexes 790k blocks and then dies on its first event. Every future chain hits the same trap. Making the fallback a compile-time or startup failure would be a small, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for resolving the DecimalFloat contract address on the Robinhood network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->